### PR TITLE
Subsystems

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -2,6 +2,7 @@ package org.sert2521.sertain
 
 import edu.wpi.first.hal.HAL
 import edu.wpi.first.wpilibj.DriverStation
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.sert2521.sertain.core.initializeWpiLib
 import org.sert2521.sertain.coroutines.RobotScope
@@ -9,35 +10,35 @@ import org.sert2521.sertain.coroutines.periodic
 import org.sert2521.sertain.events.*
 import org.sert2521.sertain.subsystems.manageSubsystems
 
-class Robot : RobotScope() {
+class Robot {
     var mode: RobotMode = RobotMode.DISCONNECTED
         internal set
 
-    fun onConnect(action: suspend (event: Connect) -> Unit) {
+    fun CoroutineScope.onConnect(action: suspend (event: Connect) -> Unit) {
         launch { subscribe(action) }
     }
 
-    fun onDisable(action: suspend (event: Disable) -> Unit) {
+    fun CoroutineScope.onDisable(action: suspend (event: Disable) -> Unit) {
         launch { subscribe(action) }
     }
 
-    fun onEnable(action: suspend (event: Enable) -> Unit) {
+    fun CoroutineScope.onEnable(action: suspend (event: Enable) -> Unit) {
         launch { subscribe(action) }
     }
 
-    fun onTeleop(action: suspend (event: Teleop) -> Unit) {
+    fun CoroutineScope.onTeleop(action: suspend (event: Teleop) -> Unit) {
         launch { subscribe(action) }
     }
 
-    fun onAuto(action: suspend (event: Auto) -> Unit) {
+    fun CoroutineScope.onAuto(action: suspend (event: Auto) -> Unit) {
         launch { subscribe(action) }
     }
 
-    fun onTest(action: suspend (event: Test) -> Unit) {
+    fun CoroutineScope.onTest(action: suspend (event: Test) -> Unit) {
         launch { subscribe(action) }
     }
 
-    fun onTick(action: suspend (event: Tick) -> Unit) {
+    fun CoroutineScope.onTick(action: suspend (event: Tick) -> Unit) {
         launch { subscribe(action) }
     }
 }
@@ -61,11 +62,9 @@ suspend fun robot(configure: Robot.() -> Unit) {
 
     manageSubsystems()
 
-    val robot = Robot().apply {
-        configure()
-    }
+    val robot = Robot().apply(configure)
 
-    robot.launch {
+    RobotScope.launch {
         periodic(20) {
             launch {
                 fire(Tick)

--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -7,7 +7,7 @@ import org.sert2521.sertain.core.initializeWpiLib
 import org.sert2521.sertain.coroutines.RobotScope
 import org.sert2521.sertain.coroutines.periodic
 import org.sert2521.sertain.events.*
-import org.sert2521.sertain.subsystems.initializeSubsystems
+import org.sert2521.sertain.subsystems.manageSubsystems
 
 class Robot : RobotScope() {
     var mode: RobotMode = RobotMode.DISCONNECTED
@@ -59,9 +59,10 @@ suspend fun robot(configure: Robot.() -> Unit) {
     val ds: DriverStation = DriverStation.getInstance()
     val running = true
 
-    initializeSubsystems()
-
-    val robot = Robot().apply(configure)
+    val robot = Robot().apply {
+        configure()
+        manageSubsystems()
+    }
 
     robot.launch {
         periodic(20) {

--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -7,6 +7,7 @@ import org.sert2521.sertain.core.initializeWpiLib
 import org.sert2521.sertain.coroutines.RobotScope
 import org.sert2521.sertain.coroutines.periodic
 import org.sert2521.sertain.events.*
+import org.sert2521.sertain.subsystems.initializeSubsystems
 
 class Robot : RobotScope() {
     var mode: RobotMode = RobotMode.DISCONNECTED
@@ -57,6 +58,8 @@ suspend fun robot(configure: Robot.() -> Unit) {
 
     val ds: DriverStation = DriverStation.getInstance()
     val running = true
+
+    initializeSubsystems()
 
     val robot = Robot().apply(configure)
 

--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -59,9 +59,10 @@ suspend fun robot(configure: Robot.() -> Unit) {
     val ds: DriverStation = DriverStation.getInstance()
     val running = true
 
+    manageSubsystems()
+
     val robot = Robot().apply {
         configure()
-        manageSubsystems()
     }
 
     robot.launch {

--- a/core/src/main/kotlin/org/sert2521/sertain/events/EventBus.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/EventBus.kt
@@ -9,7 +9,7 @@ suspend fun <E : Event> fire(event: E) {
     events.send(event)
 }
 
-suspend inline fun <reified E> subscribe(noinline action: suspend (E) -> Unit) =
+suspend inline fun <reified E : Event> subscribe(noinline action: suspend (E) -> Unit) =
         events.asFlow().filter { it is E }.map { it as E }.apply { collect(action) }
 
 suspend inline fun <T, reified E : TargetedEvent<T>> subscribe(target: T, noinline action: suspend (E) -> Unit) =

--- a/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
@@ -11,7 +11,8 @@ abstract class TaskEvent : Event()
 class Use<R>(
         val subsystems: Set<Subsystem>,
         val important: Boolean,
-        val callerContext: CoroutineContext,
+        val name: String,
+        val context: CoroutineContext,
         val continuation: CancellableContinuation<R>,
         val action: suspend CoroutineScope.() -> R
 ) : TaskEvent()

--- a/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
@@ -1,14 +1,16 @@
 package org.sert2521.sertain.events
 
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
 import org.sert2521.sertain.subsystems.Subsystem
 import kotlin.coroutines.CoroutineContext
 
 abstract class TaskEvent : Event()
 
-class Use(
+class Use<R>(
         val subsystems: Set<Subsystem>,
         val important: Boolean,
         val callerContext: CoroutineContext,
-        val action: suspend CoroutineScope.() -> Unit
+        val continuation: CancellableContinuation<R>,
+        val action: suspend CoroutineScope.() -> R
 ) : TaskEvent()

--- a/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.Job
 import org.sert2521.sertain.subsystems.Subsystem
 import kotlin.coroutines.CoroutineContext
 
-abstract class TaskEvent : Event()
+abstract class SubsystemEvent : Event()
 
 class Use<R>(
         val subsystems: Set<Subsystem>,
@@ -15,9 +15,9 @@ class Use<R>(
         val context: CoroutineContext,
         val continuation: CancellableContinuation<R>,
         val action: suspend CoroutineScope.() -> R
-) : TaskEvent()
+) : SubsystemEvent()
 
 class Clean(
         val subsystems: Set<Subsystem>,
         val job: Job
-) : TaskEvent()
+) : SubsystemEvent()

--- a/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
@@ -2,6 +2,7 @@ package org.sert2521.sertain.events
 
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import org.sert2521.sertain.subsystems.Subsystem
 import kotlin.coroutines.CoroutineContext
 
@@ -13,4 +14,9 @@ class Use<R>(
         val callerContext: CoroutineContext,
         val continuation: CancellableContinuation<R>,
         val action: suspend CoroutineScope.() -> R
+) : TaskEvent()
+
+class Clean(
+        val subsystems: Set<Subsystem>,
+        val job: Job
 ) : TaskEvent()

--- a/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
@@ -1,8 +1,14 @@
 package org.sert2521.sertain.events
 
+import kotlinx.coroutines.CoroutineScope
 import org.sert2521.sertain.subsystems.Subsystem
-import org.sert2521.sertain.subsystems.Task
+import kotlin.coroutines.CoroutineContext
 
 abstract class TaskEvent : Event()
 
-class Use(val subsystems: Set<Subsystem>, val important: Boolean, val action: suspend () -> Unit) : TaskEvent()
+class Use(
+        val subsystems: Set<Subsystem>,
+        val important: Boolean,
+        val callerContext: CoroutineContext,
+        val action: suspend CoroutineScope.() -> Unit
+) : TaskEvent()

--- a/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
@@ -1,0 +1,8 @@
+package org.sert2521.sertain.events
+
+import org.sert2521.sertain.subsystems.Subsystem
+import org.sert2521.sertain.subsystems.Task
+
+abstract class TaskEvent : Event()
+
+class Use(val subsystems: Set<Subsystem>, val important: Boolean, val action: suspend () -> Unit) : TaskEvent()

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -21,6 +21,10 @@ abstract class Subsystem {
     fun default(action: suspend CoroutineScope.() -> Unit) {
         default = action
     }
+
+    fun noDefault() {
+        default = null
+    }
 }
 
 suspend fun <R> use(vararg subsystems: Subsystem, important: Boolean = true, action: suspend CoroutineScope.() -> R): R {

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -9,6 +9,8 @@ import org.sert2521.sertain.events.fire
 import kotlin.coroutines.coroutineContext
 
 abstract class Subsystem {
+    var isEnabled = true
+
     internal var currentJob: Job? = null
 
     val occupied: Boolean

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -22,5 +22,3 @@ fun clear(subsystem: Subsystem, important: Boolean = true): Boolean {
     }
     return false
 }
-
-fun use(subsystems: Subsystem)

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -14,7 +14,7 @@ abstract class Subsystem {
     internal var currentJob: Job? = null
 
     val occupied: Boolean
-        get() = currentJob?.isActive ?: false
+        get() = currentJob != null
 
     internal var default: (suspend CoroutineScope.() -> Unit)? = null
 

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -4,21 +4,19 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
-import org.sert2521.sertain.coroutines.RobotScope
 import org.sert2521.sertain.events.Use
-import org.sert2521.sertain.events.events
 import org.sert2521.sertain.events.fire
 import kotlin.coroutines.coroutineContext
 
 abstract class Subsystem {
     internal var currentJob: Job? = null
-    val inUse: Boolean
+
+    val occupied: Boolean
         get() = currentJob?.isActive ?: false
 
-    internal var default: (suspend () -> Unit)? = null
+    internal var default: (suspend CoroutineScope.() -> Unit)? = null
 
-    fun default(action: suspend () -> Unit) {
-        currentJob?.cancel()
+    fun default(action: suspend CoroutineScope.() -> Unit) {
         default = action
     }
 }

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -8,7 +8,7 @@ import org.sert2521.sertain.events.Use
 import org.sert2521.sertain.events.fire
 import kotlin.coroutines.coroutineContext
 
-abstract class Subsystem {
+abstract class Subsystem(val name: String) {
     var isEnabled = true
 
     internal var currentJob: Job? = null
@@ -27,13 +27,19 @@ abstract class Subsystem {
     }
 }
 
-suspend fun <R> use(vararg subsystems: Subsystem, important: Boolean = true, action: suspend CoroutineScope.() -> R): R {
+suspend fun <R> use(
+        vararg subsystems: Subsystem,
+        important: Boolean = true,
+        name: String = "ACTION",
+        action: suspend CoroutineScope.() -> R
+): R {
     val context = coroutineContext
     return suspendCancellableCoroutine { continuation ->
         CoroutineScope(context).launch {
             fire(Use(
                     subsystems.toSet(),
                     important,
+                    name,
                     context,
                     continuation,
                     action

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -1,0 +1,9 @@
+package org.sert2521.sertain.subsystems
+
+abstract class Subsystem {
+    internal var default: (suspend () -> Unit)? = null
+
+    fun default(action: suspend () -> Unit) {
+        default = action
+    }
+}

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.sert2521.sertain.coroutines.RobotScope
 import org.sert2521.sertain.events.Use
+import org.sert2521.sertain.events.events
 import org.sert2521.sertain.events.fire
+import kotlin.coroutines.coroutineContext
 
 abstract class Subsystem {
     internal var currentJob: Job? = null
@@ -22,12 +24,13 @@ abstract class Subsystem {
 }
 
 suspend fun <R> use(vararg subsystems: Subsystem, important: Boolean = true, action: suspend CoroutineScope.() -> R): R {
+    val context = coroutineContext
     return suspendCancellableCoroutine { continuation ->
-        RobotScope.launch {
+        CoroutineScope(context).launch {
             fire(Use(
                     subsystems.toSet(),
                     important,
-                    coroutineContext,
+                    context,
                     continuation,
                     action
             ))

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -1,9 +1,26 @@
 package org.sert2521.sertain.subsystems
 
+import kotlinx.coroutines.Job
+
 abstract class Subsystem {
+    internal var currentJob: Job? = null
+    val inUse: Boolean
+        get() = currentJob?.isActive ?: false
+
     internal var default: (suspend () -> Unit)? = null
 
     fun default(action: suspend () -> Unit) {
+        currentJob?.cancel()
         default = action
     }
 }
+
+fun clear(subsystem: Subsystem, important: Boolean = true): Boolean {
+    if (important || !subsystem.inUse) {
+        subsystem.currentJob?.cancel()
+        return true
+    }
+    return false
+}
+
+fun use(subsystems: Subsystem)

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
@@ -1,8 +1,6 @@
 package org.sert2521.sertain.subsystems
 
-import edu.wpi.first.wpilibj.DriverStation.reportError
 import kotlinx.coroutines.*
-import org.sert2521.sertain.coroutines.RobotDispatcher
 import org.sert2521.sertain.coroutines.RobotScope
 import org.sert2521.sertain.events.Use
 import org.sert2521.sertain.events.subscribe
@@ -12,7 +10,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 fun manageSubsystems() {
-    GlobalScope.launch(RobotDispatcher) {
+    RobotScope.launch {
         subscribe<Use<Any?>> { use ->
             // Subsystems used in parent coroutine
             val lastSubsystems: Set<Subsystem> = use.callerContext[Requirements] ?: emptySet()
@@ -32,7 +30,6 @@ fun manageSubsystems() {
                 try {
                     // Suspend until all conflicting jobs are canceled and joined
                     withContext(NonCancellable) {
-                        println("cancelling and joining conflicts")
                         conflictingJobs.forEach { it.cancel() }
                         conflictingJobs.forEach { it.join() }
                     }

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
@@ -1,26 +1,42 @@
 package org.sert2521.sertain.subsystems
 
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import org.sert2521.sertain.coroutines.RobotScope
-import org.sert2521.sertain.events.TaskEvent
 import org.sert2521.sertain.events.Use
 import org.sert2521.sertain.events.subscribe
-
-val uses = listOf<Use>()
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
 
 fun RobotScope.manageSubsystems() {
     launch {
         subscribe<Use> { use ->
-            // Clean up current jobs
-            use.subsystems.forEach {
-                if (it.inUse && use.important) {
-                    it.currentJob?.cancel()
+            // Subsystems used in parent coroutine
+            val lastSubsystems: Set<Subsystem> = use.callerContext[Requirements] ?: emptySet()
+            // Subsystems used in new coroutine but not in parent coroutine
+            val newSubsystems = use.subsystems - lastSubsystems
+            // Subsystems from both parent and new coroutines
+            val subsystems = use.subsystems + lastSubsystems
+            // Subsystems that are already in use
+            val conflictingSubsystems = subsystems.filter { it.inUse }
+
+            val newJob = CoroutineScope(use.callerContext).launch(
+                    Requirements(subsystems),
+                    CoroutineStart.ATOMIC
+            ) {
+                // Suspend until all conflicting jobs are canceled and joined
+                withContext(NonCancellable) {
+                    conflictingSubsystems.forEach { it.currentJob?.cancel() }
+                    conflictingSubsystems.forEach { it.currentJob?.join() }
                 }
-            }
-            val newJob = RobotScope.launch { use.action() }
-            use.subsystems.forEach {
-                it.currentJob = newJob
+
+                coroutineScope { use.action(this) }
             }
         }
     }
+}
+
+private class Requirements(
+        requirements: Set<Subsystem>
+) : Set<Subsystem> by requirements, AbstractCoroutineContextElement(Key) {
+    companion object Key : CoroutineContext.Key<Requirements>
 }

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
@@ -23,6 +23,8 @@ fun manageSubsystems() {
             // Subsystems that are already in use
             val conflictingSubsystems = subsystems.filter { it.inUse }
 
+            val conflictingJobs = conflictingSubsystems.map { it.currentJob!! }
+
             val newJob = CoroutineScope(use.callerContext).launch(
                     Requirements(subsystems),
                     CoroutineStart.ATOMIC
@@ -30,8 +32,9 @@ fun manageSubsystems() {
                 try {
                     // Suspend until all conflicting jobs are canceled and joined
                     withContext(NonCancellable) {
-                        conflictingSubsystems.forEach { it.currentJob?.cancel() }
-                        conflictingSubsystems.forEach { it.currentJob?.join() }
+                        println("cancelling and joining conflicts")
+                        conflictingJobs.forEach { it.cancel() }
+                        conflictingJobs.forEach { it.join() }
                     }
 
                     val result = coroutineScope { use.action(this) }

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
@@ -1,6 +1,8 @@
 package org.sert2521.sertain.subsystems
 
+import edu.wpi.first.wpilibj.DriverStation.reportError
 import kotlinx.coroutines.*
+import org.sert2521.sertain.coroutines.RobotDispatcher
 import org.sert2521.sertain.coroutines.RobotScope
 import org.sert2521.sertain.events.Use
 import org.sert2521.sertain.events.subscribe
@@ -9,8 +11,8 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-fun RobotScope.manageSubsystems() {
-    launch {
+fun manageSubsystems() {
+    GlobalScope.launch(RobotDispatcher) {
         subscribe<Use<Any?>> { use ->
             // Subsystems used in parent coroutine
             val lastSubsystems: Set<Subsystem> = use.callerContext[Requirements] ?: emptySet()

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
@@ -1,0 +1,26 @@
+package org.sert2521.sertain.subsystems
+
+import kotlinx.coroutines.launch
+import org.sert2521.sertain.coroutines.RobotScope
+import org.sert2521.sertain.events.TaskEvent
+import org.sert2521.sertain.events.Use
+import org.sert2521.sertain.events.subscribe
+
+val uses = listOf<Use>()
+
+fun RobotScope.manageSubsystems() {
+    launch {
+        subscribe<Use> { use ->
+            // Clean up current jobs
+            use.subsystems.forEach {
+                if (it.inUse && use.important) {
+                    it.currentJob?.cancel()
+                }
+            }
+            val newJob = RobotScope.launch { use.action() }
+            use.subsystems.forEach {
+                it.currentJob = newJob
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Task.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Task.kt
@@ -1,3 +1,0 @@
-package org.sert2521.sertain.subsystems
-
-class Task(val action: suspend () -> Unit, val important: Boolean = true)

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Task.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Task.kt
@@ -1,0 +1,3 @@
+package org.sert2521.sertain.subsystems
+
+class Task(val action: suspend () -> Unit, val important: Boolean = true)


### PR DESCRIPTION
Add `Subsystem` class and `use` function. Uses the global event bus. Also supports nested `use` calls like meanlib.

Also, now listeners respect the scope of the current coroutine. In other words, if within the action of a `use` call you subscribe to the `Tick` event using `onTick`, the listener will by default be killed when the `use` action completes.