### PR TITLE
Improve subsystems

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -2,7 +2,6 @@ package org.sert2521.sertain
 
 import edu.wpi.first.hal.HAL
 import edu.wpi.first.wpilibj.DriverStation
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.sert2521.sertain.core.initializeWpiLib
 import org.sert2521.sertain.coroutines.RobotScope
@@ -48,34 +47,6 @@ class Robot {
         val subsystem = access(S::class)
         this += subsystem
         return subsystem
-    }
-
-    fun CoroutineScope.onConnect(action: suspend (event: Connect) -> Unit) {
-        launch { subscribe(action) }
-    }
-
-    fun CoroutineScope.onDisable(action: suspend (event: Disable) -> Unit) {
-        launch { subscribe(action) }
-    }
-
-    fun CoroutineScope.onEnable(action: suspend (event: Enable) -> Unit) {
-        launch { subscribe(action) }
-    }
-
-    fun CoroutineScope.onTeleop(action: suspend (event: Teleop) -> Unit) {
-        launch { subscribe(action) }
-    }
-
-    fun CoroutineScope.onAuto(action: suspend (event: Auto) -> Unit) {
-        launch { subscribe(action) }
-    }
-
-    fun CoroutineScope.onTest(action: suspend (event: Test) -> Unit) {
-        launch { subscribe(action) }
-    }
-
-    fun CoroutineScope.onTick(action: suspend (event: Tick) -> Unit) {
-        launch { subscribe(action) }
     }
 }
 

--- a/core/src/main/kotlin/org/sert2521/sertain/events/RobotEventSubscribers.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/RobotEventSubscribers.kt
@@ -1,0 +1,32 @@
+package org.sert2521.sertain.events
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+fun CoroutineScope.onConnect(action: suspend (event: Connect) -> Unit) {
+    launch { subscribe(action) }
+}
+
+fun CoroutineScope.onDisable(action: suspend (event: Disable) -> Unit) {
+    launch { subscribe(action) }
+}
+
+fun CoroutineScope.onEnable(action: suspend (event: Enable) -> Unit) {
+    launch { subscribe(action) }
+}
+
+fun CoroutineScope.onTeleop(action: suspend (event: Teleop) -> Unit) {
+    launch { subscribe(action) }
+}
+
+fun CoroutineScope.onAuto(action: suspend (event: Auto) -> Unit) {
+    launch { subscribe(action) }
+}
+
+fun CoroutineScope.onTest(action: suspend (event: Test) -> Unit) {
+    launch { subscribe(action) }
+}
+
+fun CoroutineScope.onTick(action: suspend (event: Tick) -> Unit) {
+    launch { subscribe(action) }
+}

--- a/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
@@ -3,6 +3,7 @@ package org.sert2521.sertain.events
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import org.sert2521.sertain.subsystems.ActionConfigure
 import org.sert2521.sertain.subsystems.Subsystem
 import kotlin.coroutines.CoroutineContext
 

--- a/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
@@ -3,7 +3,6 @@ package org.sert2521.sertain.events
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import org.sert2521.sertain.subsystems.ActionConfigure
 import org.sert2521.sertain.subsystems.Subsystem
 import kotlin.coroutines.CoroutineContext
 
@@ -11,7 +10,7 @@ abstract class SubsystemEvent : Event()
 
 class Use<R>(
         val subsystems: Set<Subsystem>,
-        val important: Boolean,
+        val cancelConflicts: Boolean,
         val name: String,
         val context: CoroutineContext,
         val continuation: CancellableContinuation<R>,

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -30,7 +30,7 @@ abstract class Subsystem(val name: String) {
 suspend fun <R> use(
         vararg subsystems: Subsystem,
         cancelConflicts: Boolean = true,
-        name: String = "ACTION",
+        name: String = "ANONYMOUS_TASK",
         action: suspend CoroutineScope.() -> R
 ): R {
     val context = coroutineContext

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -29,7 +29,7 @@ abstract class Subsystem(val name: String) {
 
 suspend fun <R> use(
         vararg subsystems: Subsystem,
-        important: Boolean = true,
+        cancelConflicts: Boolean = true,
         name: String = "ACTION",
         action: suspend CoroutineScope.() -> R
 ): R {
@@ -38,7 +38,7 @@ suspend fun <R> use(
         CoroutineScope(context).launch {
             fire(Use(
                     subsystems.toSet(),
-                    important,
+                    cancelConflicts,
                     name,
                     context,
                     continuation,

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/SubsystemManager.kt
@@ -33,7 +33,7 @@ fun manageSubsystems() {
             // Subsystems that are already occupied
             val occupiedSubsystems = allSubsystems.filter { it.occupied }
 
-            if (!use.important && occupiedSubsystems.isNotEmpty()) {
+            if (!use.cancelConflicts && occupiedSubsystems.isNotEmpty()) {
                 use.continuation.resumeWithException(
                         CancellationException(
                                 "Cannot execute unimportant action ${use.name} because the following subsystems are " +

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Tasks.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Tasks.kt
@@ -1,0 +1,31 @@
+package org.sert2521.sertain.subsystems
+
+import kotlinx.coroutines.CoroutineScope
+
+class TaskConfigure {
+    internal val subsystems = mutableListOf<Subsystem>()
+
+    operator fun plusAssign(subsystem: Subsystem) {
+        subsystems += subsystem
+    }
+
+    internal var action: (suspend CoroutineScope.() -> Unit)? = null
+
+    fun action(action: suspend CoroutineScope.() -> Unit) {
+        this.action = action
+    }
+}
+
+suspend fun doTask(configure: TaskConfigure.() -> Unit) {
+    with(TaskConfigure().apply(configure)) {
+        action?.let { action ->
+            use(*subsystems.toTypedArray(), action = action)
+        }
+    }
+}
+
+val Subsystem.accessor: TaskConfigure.() -> Subsystem
+        get() = {
+            this += this@accessor
+            this@accessor
+        }

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Tasks.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Tasks.kt
@@ -16,6 +16,11 @@ class TaskConfigure {
     fun action(action: suspend CoroutineScope.() -> Unit) {
         this.action = action
     }
+
+    fun <S : Subsystem> S.use(): S {
+        subsystems += this
+        return this
+    }
 }
 
 suspend fun doTask(name: String = "ANONYMOUS_TASK", configure: TaskConfigure.() -> Unit) {
@@ -27,8 +32,7 @@ suspend fun doTask(name: String = "ANONYMOUS_TASK", configure: TaskConfigure.() 
     }
 }
 
-val <S : Subsystem> S.accessor: TaskConfigure.() -> S
-        get() = {
-            this += this@accessor
-            this@accessor
-        }
+fun <S : Subsystem> TaskConfigure.use(subsystem: S): S {
+    this += subsystem
+    return subsystem
+}

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Tasks.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Tasks.kt
@@ -18,10 +18,6 @@ class TaskConfigure {
     }
 }
 
-class ActionConfigure : CoroutineScope {
-    override val coroutineContext: CoroutineContext = RobotDispatcher
-}
-
 suspend fun doTask(name: String = "ANONYMOUS_TASK", configure: TaskConfigure.() -> Unit) {
     with(TaskConfigure().apply(configure)) {
         action?.let {


### PR DESCRIPTION
New syntax for subsystems, based on react hooks. Now you can do
```
doTask {
	val drivetrain = useDrivetrain()
	action {
		drivetrain.vroom()
	}
}
```
When using this syntax, you cannot access subsystems without calling their `accessor` first. You can get the accessor like
```
val useDrivetrian = Drivetrain.accessor
```
Also renamed `important` to `cancelConflicts`