### PR TITLE
Improve unit math

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/motors/Encoder.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/Encoder.kt
@@ -11,4 +11,4 @@ class Encoder(ticksPerRevolution: Int) {
     val ticksPerSecond = ticks / Seconds
 }
 
-class EncoderTicks(ticksPerRevolution: Int) : MetricUnit<Angular>(Angular, (PI * 2) / ticksPerRevolution)
+class EncoderTicks(ticksPerRevolution: Int) : MetricUnit<Angular>(Angular, (PI * 2) / ticksPerRevolution, " ticks")

--- a/core/src/main/kotlin/org/sert2521/sertain/units/CompositeUnit.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/CompositeUnit.kt
@@ -5,17 +5,17 @@ sealed class CompositionOperation
 object Per : CompositionOperation()
 object By : CompositionOperation()
 
-class CompositeUnitType<OP : CompositionOperation, T1 : MetricUnitType, T2 : MetricUnitType>(
-    operation: OP,
-    type1: T1,
-    type2: T2
+data class CompositeUnitType<OP : CompositionOperation, T1 : MetricUnitType, T2 : MetricUnitType>(
+    val operation: OP,
+    val type1: T1,
+    val type2: T2
 ) : MetricUnitType()
 
 // By operation is not well tested!
-class CompositeUnit<OP : CompositionOperation, T1 : MetricUnitType, T2 : MetricUnitType>(
-    operation: OP,
-    unit1: MetricUnit<T1>,
-    unit2: MetricUnit<T2>
+data class CompositeUnit<OP : CompositionOperation, T1 : MetricUnitType, T2 : MetricUnitType>(
+    val operation: OP,
+    val unit1: MetricUnit<T1>,
+    val unit2: MetricUnit<T2>
 ) : MetricUnit<CompositeUnitType<OP, T1, T2>>(
         CompositeUnitType(operation, unit1.type, unit2.type),
         when (operation) {

--- a/core/src/main/kotlin/org/sert2521/sertain/units/CompositeUnit.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/CompositeUnit.kt
@@ -24,6 +24,19 @@ class CompositeUnit<OP : CompositionOperation, T1 : MetricUnitType, T2 : MetricU
             Per -> unit1.base / unit2.base
             By -> unit1.base * unit2.base
             else -> throw IllegalArgumentException("Unsupported unit operation")
+        },
+        when (operation) {
+            Per -> if (unit1 != unit2) {
+                " ${unit1.symbol.trim()}/${unit2.symbol.trim()}"
+            } else {
+                ""
+            }
+            By -> if (unit1 != unit2) {
+                " ${unit1.symbol.trim()}-${unit2.symbol.trim()}"
+            } else {
+                " ${unit1.symbol.trim()}²"
+            }
+            else -> throw IllegalArgumentException("Unsupported unit operation")
         }
 )
 

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricUnit.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricUnit.kt
@@ -2,33 +2,34 @@ package org.sert2521.sertain.units
 
 import kotlin.math.PI
 
-abstract class MetricUnit<T : MetricUnitType>(val type: T, val base: Double)
+abstract class MetricUnit<T : MetricUnitType>(val type: T, val base: Double, val symbol: String)
 
-abstract class ChronicUnit(seconds: Double) : MetricUnit<Chronic>(Chronic, seconds)
+abstract class ChronicUnit(seconds: Double, symbol: String) : MetricUnit<Chronic>(Chronic, seconds, symbol)
 
-object Seconds : ChronicUnit(1.0)
-object Minutes : ChronicUnit(60.0)
-object Milliseconds : ChronicUnit(0.001)
+object Seconds : ChronicUnit(1.0, " s")
+object Minutes : ChronicUnit(60.0, " min")
+object Milliseconds : ChronicUnit(0.001, " ms")
 
-abstract class LinearUnit(meters: Double) : MetricUnit<Linear>(Linear, meters)
+abstract class LinearUnit(meters: Double, symbol: String) : MetricUnit<Linear>(Linear, meters, symbol)
 
-object Meters : LinearUnit(1.0)
-object Millimeters : LinearUnit(0.001)
+object Meters : LinearUnit(1.0, " m")
+object Centimeters : LinearUnit(0.01, " cm")
+object Millimeters : LinearUnit(0.001, " mm")
 
-abstract class AngularUnit(radians: Double) : MetricUnit<Angular>(Angular, radians)
+abstract class AngularUnit(radians: Double, symbol: String) : MetricUnit<Angular>(Angular, radians, symbol)
 
-object Degrees : AngularUnit(PI / 180)
-object Radians : AngularUnit(1.0)
-object Revolutions : AngularUnit(PI * 2)
+object Degrees : AngularUnit(PI / 180, "°")
+object Radians : AngularUnit(1.0, " rad")
+object Revolutions : AngularUnit(PI * 2, " rev")
 
-abstract class LinearVelocityUnit(metersPerSecond: Double) : MetricUnit<LinearVelocity>(LinearVelocity, metersPerSecond)
+abstract class LinearVelocityUnit(metersPerSecond: Double, symbol: String) : MetricUnit<LinearVelocity>(LinearVelocity, metersPerSecond, symbol)
 
-object MetersPerSecond : LinearVelocityUnit(1.0)
-object MillimetersPerSecond : LinearVelocityUnit(0.001)
+object MetersPerSecond : LinearVelocityUnit(1.0, " m/s")
+object MillimetersPerSecond : LinearVelocityUnit(0.001, " mm/s")
 
-abstract class AngularVelocityUnit(radiansPerSecond: Double) : MetricUnit<AngularVelocity>(AngularVelocity, radiansPerSecond)
+abstract class AngularVelocityUnit(radiansPerSecond: Double, symbol: String) : MetricUnit<AngularVelocity>(AngularVelocity, radiansPerSecond, symbol)
 
-object RadiansPerSecond : AngularVelocityUnit(1.0)
-object DegreesPerSecond : AngularVelocityUnit(PI / 180)
-object RevolutionsPerSecond : AngularVelocityUnit(PI * 2)
-object RevolutionsPerMinute : AngularVelocityUnit((PI * 2) / 60)
+object RadiansPerSecond : AngularVelocityUnit(1.0, " rad/s")
+object DegreesPerSecond : AngularVelocityUnit(PI / 180, "°/s")
+object RevolutionsPerSecond : AngularVelocityUnit(PI * 2, " rev/s")
+object RevolutionsPerMinute : AngularVelocityUnit((PI * 2) / 60, " rev/min")

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
@@ -9,22 +9,27 @@ data class MetricValue<T : MetricUnitType, U : MetricUnit<T>>(val unit: U, val v
         false
     }
 
-    inline operator fun <reified R : T> plus(other: MetricValue<R, *>) =
-            MetricValue(unit, value + (other.value * other.unit.base / unit.base))
+    @Suppress("UNCHECKED_CAST")
+    inline operator fun <reified R : T, S : MetricUnit<R>> plus(other: MetricValue<R, S>) =
+            MetricValue(unit, value + other.convertTo(unit as MetricUnit<R>).value)
 
-    inline operator fun <reified R : T> minus(other: MetricValue<R, *>) =
-            MetricValue(unit, value - (other.value * other.unit.base / unit.base))
+    @Suppress("UNCHECKED_CAST")
+    inline operator fun <reified R : T, S : MetricUnit<R>> minus(other: MetricValue<R, S>) =
+            MetricValue(unit, value - other.convertTo(unit as MetricUnit<R>).value)
 
-    inline operator fun <reified R : T> times(other: MetricValue<R, *>) =
-            MetricValue(CompositeUnit(By, unit, unit), value * (other.value * other.unit.base / unit.base))
+    @Suppress("UNCHECKED_CAST")
+    inline operator fun <reified R : T, S : MetricUnit<R>> times(other: MetricValue<R, S>) =
+            MetricValue(CompositeUnit(By, unit, unit), value * other.convertTo(unit as MetricUnit<R>).value)
 
-    inline operator fun <reified R : T> div(other: MetricValue<R, *>) =
-            value / (other.value * other.unit.base / unit.base)
+    @Suppress("UNCHECKED_CAST")
+    inline operator fun <reified R : T, S : MetricUnit<R>> div(other: MetricValue<R, S>) =
+            value / other.convertTo(unit as MetricUnit<R>).value
 
-    inline operator fun <reified R : T> rem(other: MetricValue<R, *>) =
-            MetricValue(unit, value % (other.value * other.unit.base / unit.base))
+    @Suppress("UNCHECKED_CAST")
+    inline operator fun <reified R : T, S : MetricUnit<R>> rem(other: MetricValue<R, S>) =
+            MetricValue(unit, value % other.convertTo(unit as MetricUnit<R>).value)
 
-    inline operator fun <reified R : T> compareTo(other: MetricValue<R, *>) =
+    inline operator fun <reified R : T, S : MetricUnit<R>> compareTo(other: MetricValue<R, S>) =
             ceil(value * unit.base - other.value * other.unit.base).toInt()
 
     override fun hashCode(): Int {

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
@@ -1,10 +1,46 @@
 package org.sert2521.sertain.units
 
-class MetricValue<T : MetricUnitType, U : MetricUnit<T>>(val unit: U, val value: Double)
+import kotlin.math.ceil
+
+data class MetricValue<T : MetricUnitType, U : MetricUnit<T>>(val unit: U, val value: Double) {
+    override fun equals(other: Any?) = if (other is MetricValue<*, *> && unit.type == other.unit.type) {
+        value * unit.base == other.value * other.unit.base
+    } else {
+        false
+    }
+
+    inline operator fun <reified R : T> plus(other: MetricValue<R, *>) =
+            MetricValue(unit, value + (other.value * other.unit.base / unit.base))
+
+    inline operator fun <reified R : T> minus(other: MetricValue<R, *>) =
+            MetricValue(unit, value - (other.value * other.unit.base / unit.base))
+
+    inline operator fun <reified R : T> times(other: MetricValue<R, *>) =
+            MetricValue(CompositeUnit(By, unit, unit), value * (other.value * other.unit.base / unit.base))
+
+    inline operator fun <reified R : T> div(other: MetricValue<R, *>) =
+            value / (other.value * other.unit.base / unit.base)
+
+    inline operator fun <reified R : T> rem(other: MetricValue<R, *>) =
+            MetricValue(unit, value % (other.value * other.unit.base / unit.base))
+
+    inline operator fun <reified R : T> compareTo(other: MetricValue<R, *>) =
+            ceil(value * unit.base - other.value * other.unit.base).toInt()
+
+    override fun hashCode(): Int {
+        var result = unit.hashCode()
+        result = 31 * result + value.hashCode()
+        return result
+    }
+
+    override fun toString() = "$value${unit.symbol}"
+}
 
 val Number.s get() = MetricValue(Seconds, toDouble())
+val Number.min get() = MetricValue(Minutes, toDouble())
 val Number.ms get() = MetricValue(Milliseconds, toDouble())
 val Number.m get() = MetricValue(Meters, toDouble())
+val Number.cm get() = MetricValue(Centimeters, toDouble())
 val Number.mm get() = MetricValue(Millimeters, toDouble())
 val Number.deg get() = MetricValue(Degrees, toDouble())
 val Number.rad get() = MetricValue(Radians, toDouble())

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
@@ -10,26 +10,26 @@ data class MetricValue<T : MetricUnitType, U : MetricUnit<T>>(val unit: U, val v
     }
 
     @Suppress("UNCHECKED_CAST")
-    inline operator fun <reified R : T, S : MetricUnit<R>> plus(other: MetricValue<R, S>) =
+    operator fun <R : T, S : MetricUnit<R>> plus(other: MetricValue<R, S>) =
             MetricValue(unit, value + other.convertTo(unit as MetricUnit<R>).value)
 
     @Suppress("UNCHECKED_CAST")
-    inline operator fun <reified R : T, S : MetricUnit<R>> minus(other: MetricValue<R, S>) =
+    operator fun <R : T, S : MetricUnit<R>> minus(other: MetricValue<R, S>) =
             MetricValue(unit, value - other.convertTo(unit as MetricUnit<R>).value)
 
     @Suppress("UNCHECKED_CAST")
-    inline operator fun <reified R : T, S : MetricUnit<R>> times(other: MetricValue<R, S>) =
+    operator fun <R : T, S : MetricUnit<R>> times(other: MetricValue<R, S>) =
             MetricValue(CompositeUnit(By, unit, unit), value * other.convertTo(unit as MetricUnit<R>).value)
 
     @Suppress("UNCHECKED_CAST")
-    inline operator fun <reified R : T, S : MetricUnit<R>> div(other: MetricValue<R, S>) =
+    operator fun <R : T, S : MetricUnit<R>> div(other: MetricValue<R, S>) =
             value / other.convertTo(unit as MetricUnit<R>).value
 
     @Suppress("UNCHECKED_CAST")
-    inline operator fun <reified R : T, S : MetricUnit<R>> rem(other: MetricValue<R, S>) =
+    operator fun <R : T, S : MetricUnit<R>> rem(other: MetricValue<R, S>) =
             MetricValue(unit, value % other.convertTo(unit as MetricUnit<R>).value)
 
-    inline operator fun <reified R : T, S : MetricUnit<R>> compareTo(other: MetricValue<R, S>) =
+    operator fun <R : T, S : MetricUnit<R>> compareTo(other: MetricValue<R, S>) =
             ceil(value * unit.base - other.value * other.unit.base).toInt()
 
     override fun hashCode(): Int {

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
@@ -9,27 +9,30 @@ data class MetricValue<T : MetricUnitType, U : MetricUnit<T>>(val unit: U, val v
         false
     }
 
-    @Suppress("UNCHECKED_CAST")
-    operator fun <R : T, S : MetricUnit<R>> plus(other: MetricValue<R, S>) =
-            MetricValue(unit, value + other.convertTo(unit as MetricUnit<R>).value)
+    operator fun <S : MetricUnit<T>> plus(other: MetricValue<T, S>) =
+            MetricValue(unit, value + other.convertTo(unit).value)
+
+    operator fun <S : MetricUnit<T>> minus(other: MetricValue<T, S>) =
+            MetricValue(unit, value - other.convertTo(unit).value)
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <R : T, S : MetricUnit<R>> minus(other: MetricValue<R, S>) =
-            MetricValue(unit, value - other.convertTo(unit as MetricUnit<R>).value)
+    operator fun <R : MetricUnitType, S : MetricUnit<R>> times(other: MetricValue<*, S>) = if (unit.type == other.unit.type) {
+        MetricValue(CompositeUnit(By, unit, unit), value * (other as MetricValue<T, U>).convertTo(unit).value)
+    } else {
+        MetricValue(CompositeUnit(By, unit, other.unit), value * other.value)
+    }
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <R : T, S : MetricUnit<R>> times(other: MetricValue<R, S>) =
-            MetricValue(CompositeUnit(By, unit, unit), value * other.convertTo(unit as MetricUnit<R>).value)
+    operator fun <R : MetricUnitType, S : MetricUnit<R>> div(other: MetricValue<*, S>) = if (unit.type == other.unit.type) {
+        MetricValue(CompositeUnit(Per, unit, unit), value / (other as MetricValue<T, U>).convertTo(unit).value)
+    } else {
+        MetricValue(CompositeUnit(Per, unit, other.unit), value / other.value)
+    }
 
-    @Suppress("UNCHECKED_CAST")
-    operator fun <R : T, S : MetricUnit<R>> div(other: MetricValue<R, S>) =
-            value / other.convertTo(unit as MetricUnit<R>).value
+    operator fun <S : MetricUnit<T>> rem(other: MetricValue<T, S>) =
+            MetricValue(unit, value % other.convertTo(unit).value)
 
-    @Suppress("UNCHECKED_CAST")
-    operator fun <R : T, S : MetricUnit<R>> rem(other: MetricValue<R, S>) =
-            MetricValue(unit, value % other.convertTo(unit as MetricUnit<R>).value)
-
-    operator fun <R : T, S : MetricUnit<R>> compareTo(other: MetricValue<R, S>) =
+    operator fun <S : MetricUnit<T>> compareTo(other: MetricValue<T, S>) =
             ceil(value * unit.base - other.value * other.unit.base).toInt()
 
     override fun hashCode(): Int {


### PR DESCRIPTION
### This depends on #13 

```kotlin
fun main() {
    println(90.deg > 1.rev) // false
    println(PI.rad == 180.deg) // true

    println(300.cm + 2.m) // 500.0 cm
    println(10.m + 200.cm + 8.m + 259.mm) // 20.259 m

    println(1.rev / 90.deg) // 4.0
    println((2 * PI).rad / 15.deg) // 24.0
    println(2.deg / 100.s) // 0.02 °/s

    println(100.cm * 0.5.m) // 5000.0 cm²
    println(0.5.m * 100.cm) // 0.5 m²
    println(0.5.rad * 60.m) // 30.0 rad-min

    println(100.cm * 0.5.m == 0.5.m * 100.cm) // true

    val threeQuarters = PI.rad + 90.deg
    println(threeQuarters) // 4.71238898038469 rad
    println(threeQuarters.convertTo(Revolutions)) // 0.75 rev
    println(threeQuarters.convertTo(Degrees)) // 270.0°
}

```