### PR TITLE
Improve event subscribers

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 val ktlint by configurations.creating
 
 plugins {
-    kotlin("jvm") version "1.3.41"
+    kotlin("jvm") version "1.3.50"
 }
 
 group = "org.sert2521.sertain"
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("reflect", "1.3.41"))
+    implementation(kotlin("reflect", "1.3.50"))
     implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-core", "1.3.1")
     implementation("edu.wpi.first.wpilibj", "wpilibj-java", "2019.4.1")
     implementation("edu.wpi.first.hal", "hal-java", "2019.4.1")

--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -21,7 +21,7 @@ import org.sert2521.sertain.subsystems.manageSubsystems
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
 
-class Robot {
+class Robot : RobotScope() {
     var mode = RobotMode.DISCONNECTED
         internal set
 

--- a/core/src/main/kotlin/org/sert2521/sertain/events/EventBus.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/EventBus.kt
@@ -1,11 +1,13 @@
 package org.sert2521.sertain.events
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
 @UseExperimental(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 val events = BroadcastChannel<Event>(Channel.BUFFERED)
@@ -16,12 +18,16 @@ suspend fun <E : Event> fire(event: E) {
 }
 
 @UseExperimental(kotlinx.coroutines.ExperimentalCoroutinesApi::class, kotlinx.coroutines.FlowPreview::class)
-suspend inline fun <reified E : Event> subscribe(noinline action: suspend (E) -> Unit) =
-        events.asFlow().filter { it is E }.map { it as E }.apply { collect(action) }
+inline fun <reified E : Event> CoroutineScope.subscribe(noinline action: suspend (E) -> Unit) =
+        launch {
+            events.asFlow().filter { it is E }.map { it as E }.apply { collect(action) }
+        }
 
 @UseExperimental(kotlinx.coroutines.ExperimentalCoroutinesApi::class, kotlinx.coroutines.FlowPreview::class)
-suspend inline fun <T, reified E : TargetedEvent<T>> subscribe(target: T, noinline action: suspend (E) -> Unit) =
-        events.asFlow()
-            .filter { it is E && (it as? TargetedEvent<*>)?.target == target }
-            .map { it as E }
-            .apply { collect(action) }
+suspend inline fun <T, reified E : TargetedEvent<T>> CoroutineScope.subscribe(target: T, noinline action: suspend (E) -> Unit) =
+        launch {
+            events.asFlow()
+                    .filter { it is E && (it as? TargetedEvent<*>)?.target == target }
+                    .map { it as E }
+                    .apply { collect(action) }
+        }

--- a/core/src/main/kotlin/org/sert2521/sertain/events/RobotEventSubscribers.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/RobotEventSubscribers.kt
@@ -1,32 +1,24 @@
 package org.sert2521.sertain.events
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
-fun CoroutineScope.onConnect(action: suspend (event: Connect) -> Unit) {
-    launch { subscribe(action) }
-}
+fun CoroutineScope.onConnect(action: suspend (event: Connect) -> Unit) =
+        subscribe(action)
 
-fun CoroutineScope.onDisable(action: suspend (event: Disable) -> Unit) {
-    launch { subscribe(action) }
-}
+fun CoroutineScope.onDisable(action: suspend (event: Disable) -> Unit) =
+        subscribe(action)
 
-fun CoroutineScope.onEnable(action: suspend (event: Enable) -> Unit) {
-    launch { subscribe(action) }
-}
+fun CoroutineScope.onEnable(action: suspend (event: Enable) -> Unit) =
+        subscribe(action)
 
-fun CoroutineScope.onTeleop(action: suspend (event: Teleop) -> Unit) {
-    launch { subscribe(action) }
-}
+fun CoroutineScope.onTeleop(action: suspend (event: Teleop) -> Unit) =
+        subscribe(action)
 
-fun CoroutineScope.onAuto(action: suspend (event: Auto) -> Unit) {
-    launch { subscribe(action) }
-}
+fun CoroutineScope.onAuto(action: suspend (event: Auto) -> Unit) =
+        subscribe(action)
 
-fun CoroutineScope.onTest(action: suspend (event: Test) -> Unit) {
-    launch { subscribe(action) }
-}
+fun CoroutineScope.onTest(action: suspend (event: Test) -> Unit) =
+        subscribe(action)
 
-fun CoroutineScope.onTick(action: suspend (event: Tick) -> Unit) {
-    launch { subscribe(action) }
-}
+fun CoroutineScope.onTick(action: suspend (event: Tick) -> Unit) =
+        subscribe(action)

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -26,6 +26,7 @@ class MotorController<T : MotorId>(
             if (value != null) {
                 ctreMotorController.follow(value.ctreMotorController)
             }
+            println("Init 3")
             field = value
         }
 
@@ -50,14 +51,16 @@ class MotorController<T : MotorId>(
     fun eachTalon(configure: MotorController<TalonId>.() -> Unit) {
         eachMotor {
             @Suppress("unchecked_cast") // Will work because type of id is T
-            if (id is TalonId) (this as MotorController<TalonId>).apply(configure)
+            (this as? MotorController<TalonId>)?.apply(configure)
+            Unit
         }
     }
 
     fun eachVictor(configure: MotorController<VictorId>.() -> Unit) {
         eachMotor {
             @Suppress("unchecked_cast") // Will work because type of id is T
-            if (id is VictorId) (this as MotorController<VictorId>).apply(configure)
+            (this as? MotorController<VictorId>)?.apply(configure)
+            Unit
         }
     }
 
@@ -75,6 +78,7 @@ class MotorController<T : MotorId>(
             set(value) {
                 eachMotor {
                     ctreMotorController.setNeutralMode(ctreNeutralMode(value))
+                    Unit
                 }
                 field = value
             }
@@ -169,7 +173,7 @@ class MotorController<T : MotorId>(
     }
 
     fun <U : MetricUnit<Angular>> setPosition(position: MetricValue<Angular, U>) {
-        setPosition(position.convertTo(encoder.ticks).value)
+        //setPosition(position.convertTo(encoder.ticks).value)
     }
 
     fun setVelocity(velocity: Double) {
@@ -179,7 +183,7 @@ class MotorController<T : MotorId>(
     fun <U : MetricUnit<CompositeUnitType<Per, Angular, Chronic>>> setVelocity(
         velocity: MetricValue<CompositeUnitType<Per, Angular, Chronic>, U>
     ) {
-        setVelocity(velocity.convertTo(encoder.ticksPerSecond).value)
+        //setVelocity(velocity.convertTo(encoder.ticksPerSecond).value)
     }
 
     fun setCurrent(current: Double) {

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -59,7 +59,6 @@ class MotorController<T : MotorId>(
         eachMotor {
             @Suppress("unchecked_cast") // Will work because type of id is T
             (this as? MotorController<VictorId>)?.apply(configure)
-            Unit
         }
     }
 
@@ -77,7 +76,6 @@ class MotorController<T : MotorId>(
             set(value) {
                 eachMotor {
                     ctreMotorController.setNeutralMode(ctreNeutralMode(value))
-                    Unit
                 }
                 field = value
             }
@@ -172,7 +170,7 @@ class MotorController<T : MotorId>(
     }
 
     fun <U : MetricUnit<Angular>> setPosition(position: MetricValue<Angular, U>) {
-        //setPosition(position.convertTo(encoder.ticks).value)
+        setPosition(position.convertTo(encoder.ticks).value)
     }
 
     fun setVelocity(velocity: Double) {
@@ -182,7 +180,7 @@ class MotorController<T : MotorId>(
     fun <U : MetricUnit<CompositeUnitType<Per, Angular, Chronic>>> setVelocity(
         velocity: MetricValue<CompositeUnitType<Per, Angular, Chronic>, U>
     ) {
-        //setVelocity(velocity.convertTo(encoder.ticksPerSecond).value)
+        setVelocity(velocity.convertTo(encoder.ticksPerSecond).value)
     }
 
     fun setCurrent(current: Double) {

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -26,7 +26,6 @@ class MotorController<T : MotorId>(
             if (value != null) {
                 ctreMotorController.follow(value.ctreMotorController)
             }
-            println("Init 3")
             field = value
         }
 

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -59,7 +59,6 @@ class MotorController<T : MotorId>(
         eachMotor {
             @Suppress("unchecked_cast") // Will work because type of id is T
             (this as? MotorController<VictorId>)?.apply(configure)
-            Unit
         }
     }
 
@@ -77,7 +76,6 @@ class MotorController<T : MotorId>(
             set(value) {
                 eachMotor {
                     ctreMotorController.setNeutralMode(ctreNeutralMode(value))
-                    Unit
                 }
                 field = value
             }

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorId.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorId.kt
@@ -10,8 +10,11 @@ class TalonId(number: Int) : MotorId(number)
 class VictorId(number: Int) : MotorId(number)
 
 internal fun ctreMotorController(id: MotorId): BaseMotorController {
+    println("init 1")
     return when (id) {
-        is TalonId -> TalonSRX(id.number)
+        is TalonId -> TalonSRX(id.number).also {
+            println("init 2")
+        }
         is VictorId -> VictorSPX(id.number)
     }
 }

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorId.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorId.kt
@@ -10,11 +10,8 @@ class TalonId(number: Int) : MotorId(number)
 class VictorId(number: Int) : MotorId(number)
 
 internal fun ctreMotorController(id: MotorId): BaseMotorController {
-    println("init 1")
     return when (id) {
-        is TalonId -> TalonSRX(id.number).also {
-            println("init 2")
-        }
+        is TalonId -> TalonSRX(id.number)
         is VictorId -> VictorSPX(id.number)
     }
 }


### PR DESCRIPTION
Before, the `subscribe` function suspended the parent coroutine. You would have to use `launch` each time you use it, unless you wanted to suspend the function it is called in.
```
launch {
	onEnable {
		// stuff
	}
}
```
Now, you would not have to use `launch` because `subscribe` is no longer a suspend function. So, what if you _do_ want to suspend the parent function? Easy:
```
onEnable {
	// stuff
}.join() // Join tells the function to suspend until onEnable finishes
```