### PR TITLE
Network tables

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/networktables/Table.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/networktables/Table.kt
@@ -1,0 +1,5 @@
+package org.sert2521.sertain.networktables
+
+open class Table(val name: String, val location: List<String> = emptyList()) {
+    fun <T> entry(value: T) = TableEntry(value, location + name)
+}

--- a/core/src/main/kotlin/org/sert2521/sertain/networktables/TableEntry.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/networktables/TableEntry.kt
@@ -5,7 +5,7 @@ import edu.wpi.first.networktables.NetworkTableInstance
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
-class TableEntry<T>(val value: T, val location: List<String>) : ReadWriteProperty<Any?, T> {
+class TableEntry<T>(val value: T, val location: List<String> = emptyList()) : ReadWriteProperty<Any?, T> {
     var initialized = false
 
     private val wpiTable: WpiNetworkTable get() {

--- a/core/src/main/kotlin/org/sert2521/sertain/networktables/TableEntry.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/networktables/TableEntry.kt
@@ -1,0 +1,31 @@
+package org.sert2521.sertain.networktables
+
+import edu.wpi.first.networktables.NetworkTable as WpiNetworkTable
+import edu.wpi.first.networktables.NetworkTableInstance
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+class TableEntry<T>(val value: T, val location: List<String>) : ReadWriteProperty<Any?, T> {
+    var initialized = false
+
+    private val wpiTable: WpiNetworkTable get() {
+        var table = NetworkTableInstance.getDefault().getTable(location.first())
+        location.drop(1).dropLast(0).forEach {
+            table = table.getSubTable(it)
+        }
+        return table
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        if (!initialized) {
+            setValue(thisRef, property, value)
+            initialized = true
+        }
+        return wpiTable.getEntry(property.name).value.value as T
+    }
+
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        wpiTable.getEntry(property.name).setValue(value)
+    }
+}


### PR DESCRIPTION
Network tables. Entries can be created with this delegate:
```
var someEntry by TableEntry(100, listOf("Table", "Location"))
```
If you want to be more organized, though, you can also create a `Table`:
```
object SomeTable : Table("SomeTable", listOf("Parent", "Table") {
	var someEntry by entry(100)
}
```
The `location` parameter is optional for both of these methods.