### PR TITLE
Change names

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -54,7 +54,7 @@ suspend fun robot(configure: RobotScope.() -> Unit) {
     }
 
     val mc = MotorController(TalonId(0))
-    mc.toPercentOutput(0.01)
+    mc.targetPercentOutput(0.01)
 
     subsystems
             .forEach {

--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -54,7 +54,7 @@ suspend fun robot(configure: RobotScope.() -> Unit) {
     }
 
     val mc = MotorController(TalonId(0))
-    mc.targetPercentOutput(0.01)
+    mc.setPercentOutput(0.01)
 
     subsystems
             .forEach {

--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -14,6 +14,8 @@ import org.sert2521.sertain.events.Teleop
 import org.sert2521.sertain.events.Test
 import org.sert2521.sertain.events.Tick
 import org.sert2521.sertain.events.fire
+import org.sert2521.sertain.motors.MotorController
+import org.sert2521.sertain.motors.TalonId
 import org.sert2521.sertain.subsystems.manageTasks
 import org.sert2521.sertain.subsystems.subsystems
 import org.sert2521.sertain.subsystems.use
@@ -50,6 +52,9 @@ suspend fun robot(configure: RobotScope.() -> Unit) {
             }
         }
     }
+
+    val mc = MotorController(TalonId(0))
+    mc.toPercentOutput(0.01)
 
     subsystems
             .forEach {

--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -14,8 +14,6 @@ import org.sert2521.sertain.events.Teleop
 import org.sert2521.sertain.events.Test
 import org.sert2521.sertain.events.Tick
 import org.sert2521.sertain.events.fire
-import org.sert2521.sertain.motors.MotorController
-import org.sert2521.sertain.motors.TalonId
 import org.sert2521.sertain.subsystems.manageTasks
 import org.sert2521.sertain.subsystems.subsystems
 import org.sert2521.sertain.subsystems.use

--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -53,9 +53,6 @@ suspend fun robot(configure: RobotScope.() -> Unit) {
         }
     }
 
-    val mc = MotorController(TalonId(0))
-    mc.setPercentOutput(0.01)
-
     subsystems
             .forEach {
                 it.value.default?.apply {

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -171,17 +171,17 @@ class MotorController<T : MotorId>(
     fun velocity(unit: CompositeUnit<Per, Angular, Chronic>) =
             MetricValue(encoder!!.ticksPerSecond, velocity.toDouble()).convertTo(unit)
 
-    fun targetPercentOutput(output: Double) {
+    fun setPercentOutput(output: Double) {
         ctreMotorController.set(CtreControlMode.PercentOutput, output)
     }
 
-    fun targetPosition(position: Int) {
+    fun setTargetPosition(position: Int) {
         ctreMotorController.set(CtreControlMode.Position, position.toDouble())
     }
 
-    fun <U : MetricUnit<Angular>> targetPosition(position: MetricValue<Angular, U>) {
+    fun <U : MetricUnit<Angular>> setTargetPosition(position: MetricValue<Angular, U>) {
         try {
-            targetPosition(position.convertTo(encoder!!.ticks).value.toInt())
+            setTargetPosition(position.convertTo(encoder!!.ticks).value.toInt())
         } catch (e: NullPointerException) {
             throw java.lang.IllegalStateException(
                     "You must configure your encoder to use units."
@@ -189,15 +189,15 @@ class MotorController<T : MotorId>(
         }
     }
 
-    fun targetVelocity(velocity: Int) {
+    fun setTargetVelocity(velocity: Int) {
         ctreMotorController.set(CtreControlMode.Velocity, velocity.toDouble())
     }
 
-    fun targetVelocity(
+    fun setTargetVelocity(
         velocity: MetricValue<CompositeUnitType<Per, Angular, Chronic>, CompositeUnit<Per, Angular, Chronic>>
     ) {
         try {
-            targetVelocity(velocity.convertTo(encoder!!.ticksPerSecond).value.toInt())
+            setTargetVelocity(velocity.convertTo(encoder!!.ticksPerSecond).value.toInt())
         } catch (e: NullPointerException) {
             throw java.lang.IllegalStateException(
                     "You must configure your encoder to use units."
@@ -205,7 +205,7 @@ class MotorController<T : MotorId>(
         }
     }
 
-    fun targetCurrent(current: Double) {
+    fun setCurrent(current: Double) {
         ctreMotorController.set(CtreControlMode.Current, current)
     }
 
@@ -232,10 +232,10 @@ class MotorController<T : MotorId>(
     private fun updateCurrentLimit(limit: CurrentLimit) {
         eachTalon {
             (ctreMotorController as CtreTalon).apply {
-                configContinuousCurrentLimit(currentLimit.continuousLimit)
-                configPeakCurrentLimit(currentLimit.maxLimit)
-                configPeakCurrentDuration(currentLimit.maxDuration)
-                enableCurrentLimit(currentLimit.enabled)
+                configContinuousCurrentLimit(limit.continuousLimit)
+                configPeakCurrentLimit(limit.maxLimit)
+                configPeakCurrentDuration(limit.maxDuration)
+                enableCurrentLimit(limit.enabled)
             }
         }
     }

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -8,7 +8,6 @@ import org.sert2521.sertain.units.MetricUnit
 import org.sert2521.sertain.units.MetricValue
 import org.sert2521.sertain.units.Per
 import org.sert2521.sertain.units.convertTo
-import java.lang.NullPointerException
 import com.ctre.phoenix.motorcontrol.ControlMode as CtreControlMode
 import com.ctre.phoenix.motorcontrol.NeutralMode as CtreNeutralMode
 import com.ctre.phoenix.motorcontrol.can.TalonSRX as CtreTalon

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -180,13 +180,8 @@ class MotorController<T : MotorId>(
     }
 
     fun <U : MetricUnit<Angular>> setTargetPosition(position: MetricValue<Angular, U>) {
-        try {
-            setTargetPosition(position.convertTo(encoder!!.ticks).value.toInt())
-        } catch (e: NullPointerException) {
-            throw java.lang.IllegalStateException(
-                    "You must configure your encoder to use units."
-            )
-        }
+        checkNotNull(encoder) { "You must configure your encoder to use units." }
+        setTargetPosition(position.convertTo(encoder!!.ticks).value.toInt())
     }
 
     fun setTargetVelocity(velocity: Int) {
@@ -196,13 +191,8 @@ class MotorController<T : MotorId>(
     fun setTargetVelocity(
         velocity: MetricValue<CompositeUnitType<Per, Angular, Chronic>, CompositeUnit<Per, Angular, Chronic>>
     ) {
-        try {
-            setTargetVelocity(velocity.convertTo(encoder!!.ticksPerSecond).value.toInt())
-        } catch (e: NullPointerException) {
-            throw java.lang.IllegalStateException(
-                    "You must configure your encoder to use units."
-            )
-        }
+        checkNotNull(encoder) { "You must configure your encoder to use units." }
+        setTargetVelocity(velocity.convertTo(encoder!!.ticksPerSecond).value.toInt())
     }
 
     fun setCurrent(current: Double) {

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -171,17 +171,17 @@ class MotorController<T : MotorId>(
     fun velocity(unit: CompositeUnit<Per, Angular, Chronic>) =
             MetricValue(encoder!!.ticksPerSecond, velocity.toDouble()).convertTo(unit)
 
-    fun toPercentOutput(output: Double) {
+    fun targetPercentOutput(output: Double) {
         ctreMotorController.set(CtreControlMode.PercentOutput, output)
     }
 
-    fun toPosition(position: Int) {
+    fun targetPosition(position: Int) {
         ctreMotorController.set(CtreControlMode.Position, position.toDouble())
     }
 
-    fun <U : MetricUnit<Angular>> toPosition(position: MetricValue<Angular, U>) {
+    fun <U : MetricUnit<Angular>> targetPosition(position: MetricValue<Angular, U>) {
         try {
-            toPosition(position.convertTo(encoder!!.ticks).value.toInt())
+            targetPosition(position.convertTo(encoder!!.ticks).value.toInt())
         } catch (e: NullPointerException) {
             throw java.lang.IllegalStateException(
                     "You must configure your encoder to use units."
@@ -189,15 +189,15 @@ class MotorController<T : MotorId>(
         }
     }
 
-    fun toVelocity(velocity: Int) {
+    fun targetVelocity(velocity: Int) {
         ctreMotorController.set(CtreControlMode.Velocity, velocity.toDouble())
     }
 
-    fun toVelocity(
+    fun targetVelocity(
         velocity: MetricValue<CompositeUnitType<Per, Angular, Chronic>, CompositeUnit<Per, Angular, Chronic>>
     ) {
         try {
-            toVelocity(velocity.convertTo(encoder!!.ticksPerSecond).value.toInt())
+            targetVelocity(velocity.convertTo(encoder!!.ticksPerSecond).value.toInt())
         } catch (e: NullPointerException) {
             throw java.lang.IllegalStateException(
                     "You must configure your encoder to use units."
@@ -205,11 +205,11 @@ class MotorController<T : MotorId>(
         }
     }
 
-    fun toCurrent(current: Double) {
+    fun targetCurrent(current: Double) {
         ctreMotorController.set(CtreControlMode.Current, current)
     }
 
-    fun stop() {
+    fun disable() {
         ctreMotorController.neutralOutput()
     }
 


### PR DESCRIPTION
For the names, instead of `mc.sensorPosition` this pull request would make it `mc.position`, and for `mc.setPosition(10)` it would become `mc.toPosition(20)`. Does this sound alright?