### PR TITLE
Fix maxOutput

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorPidf.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorPidf.kt
@@ -10,7 +10,7 @@ data class MotorPidf(
     val integralZone: Int = 0,
     val allowedError: Int = 0,
     val maxIntegral: Double = 0.0,
-    val maxOutput: Double = 0.0,
+    val maxOutput: Double = 1.0,
     val period: Int = 0
 )
 
@@ -18,7 +18,7 @@ class MotorPidfConfig : PidfConfig() {
     var integralZone: Int = 0
     var allowedError: Int = 0
     var maxIntegral: Double = 0.0
-    var maxOutput: Double = 0.0
+    var maxOutput: Double = 1.0
     var period: Int = 0
 }
 


### PR DESCRIPTION
Changes `maxOutput` from zero to one by default for pid.