### PR TITLE
Add type check before cast to talon or victor

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -50,14 +50,14 @@ class MotorController<T : MotorId>(
     fun eachTalon(configure: MotorController<TalonId>.() -> Unit) {
         eachMotor {
             @Suppress("unchecked_cast") // Will work because type of id is T
-            (this as? MotorController<TalonId>)?.apply(configure)
+            if (id is TalonId) (this as MotorController<TalonId>).apply(configure)
         }
     }
 
     fun eachVictor(configure: MotorController<VictorId>.() -> Unit) {
         eachMotor {
             @Suppress("unchecked_cast") // Will work because type of id is T
-            (this as? MotorController<VictorId>)?.apply(configure)
+            if (id is VictorId) (this as MotorController<VictorId>).apply(configure)
         }
     }
 


### PR DESCRIPTION
I guess the type cast to `MotorController<TalonId>` succeeded even if the id was a `VictorId`, and so later `ctreMotorController` was assumed to be a talon. I am now checking the type of `id` first before casting it to `MotorController<TalonId>` which works.