### PR TITLE
Fix pid configuration stuff

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/control/PidfController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/control/PidfController.kt
@@ -1,17 +1,17 @@
 package org.sert2521.sertain.control
 
 open class PidfConfig {
-    var kp = 0.0
-    var ki = 0.0
-    var kd = 0.0
-    var kf = 0.0
+    var kp: Double? = null
+    var ki: Double? = null
+    var kd: Double? = null
+    var kf: Double? = null
 }
 
 class PidfController(config: PidfConfig, val dt: Double) {
-    private val kp = config.kp
-    private val ki = config.ki
-    private val kd = config.kd
-    private val kf = config.kf
+    private val kp = config.kp ?: 0.0
+    private val ki = config.ki ?: 0.0
+    private val kd = config.kd ?: 0.0
+    private val kf = config.kf ?: 0.0
 
     private var integral = 0.0
     private var lastError = 0.0

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -99,12 +99,15 @@ class MotorController<T : MotorId>(
     fun pidf(slot: Int = pidfSlot, configure: MotorPidfConfig.() -> Unit) {
         with(MotorPidfConfig().apply(configure)) {
             pidf[slot] = MotorPidf(
-                kp, ki, kd, kf,
-                integralZone,
-                allowedError,
-                maxIntegral,
-                maxOutput,
-                period
+                kp ?: pidf[slot]?.kp ?: 0.0,
+                ki ?: pidf[slot]?.ki ?: 0.0,
+                kd ?: pidf[slot]?.kd ?: 0.0,
+                kf ?: pidf[slot]?.kf ?: 0.0,
+                integralZone ?: pidf[slot]?.integralZone ?: 0,
+                allowedError ?: pidf[slot]?.allowedError ?: 0,
+                maxIntegral ?: pidf[slot]?.maxIntegral ?: 0.0,
+                maxOutput ?: pidf[slot]?.maxIntegral ?: 0.0,
+                period ?: pidf[slot]?.period ?: 0
             )
         }
     }

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorPidf.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorPidf.kt
@@ -15,11 +15,11 @@ data class MotorPidf(
 )
 
 class MotorPidfConfig : PidfConfig() {
-    var integralZone: Int = 0
-    var allowedError: Int = 0
-    var maxIntegral: Double = 0.0
-    var maxOutput: Double = 1.0
-    var period: Int = 0
+    var integralZone: Int? = null
+    var allowedError: Int? = null
+    var maxIntegral: Double? = null
+    var maxOutput: Double? = null
+    var period: Int? = null
 }
 
 class MotorPidfCollection(val motor: MotorController<*>, vararg initialPidf: Pair<Int, MotorPidf>) {


### PR DESCRIPTION
Before when calling the `pidf` function in `MotorController`, all the values were reset to their default. This is not a problem if you are only calling `pidf` at the beginning of `MotorController` creation, but if you call it later and only set `p`, all other values are reset. With this pull request, the values will stay the same if they are not specified in `pidf`.