### PR TITLE
Units revamp

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -17,23 +17,6 @@ import org.sert2521.sertain.events.fire
 import org.sert2521.sertain.subsystems.manageTasks
 import org.sert2521.sertain.subsystems.subsystems
 import org.sert2521.sertain.subsystems.use
-import org.sert2521.sertain.units.MetricValue
-import org.sert2521.sertain.units.convertTo
-import org.sert2521.sertain.units.degrees
-import org.sert2521.sertain.units.div
-import org.sert2521.sertain.units.meters
-import org.sert2521.sertain.units.millimeters
-import org.sert2521.sertain.units.mmps
-import org.sert2521.sertain.units.mps
-import org.sert2521.sertain.units.mpss
-import org.sert2521.sertain.units.rad
-import org.sert2521.sertain.units.radians
-import org.sert2521.sertain.units.rdps
-import org.sert2521.sertain.units.revolutions
-import org.sert2521.sertain.units.rpss
-import org.sert2521.sertain.units.seconds
-import org.sert2521.sertain.units.times
-import kotlin.math.PI
 
 object Robot {
     var mode = RobotMode.DISCONNECTED

--- a/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/Robot.kt
@@ -17,6 +17,23 @@ import org.sert2521.sertain.events.fire
 import org.sert2521.sertain.subsystems.manageTasks
 import org.sert2521.sertain.subsystems.subsystems
 import org.sert2521.sertain.subsystems.use
+import org.sert2521.sertain.units.MetricValue
+import org.sert2521.sertain.units.convertTo
+import org.sert2521.sertain.units.degrees
+import org.sert2521.sertain.units.div
+import org.sert2521.sertain.units.meters
+import org.sert2521.sertain.units.millimeters
+import org.sert2521.sertain.units.mmps
+import org.sert2521.sertain.units.mps
+import org.sert2521.sertain.units.mpss
+import org.sert2521.sertain.units.rad
+import org.sert2521.sertain.units.radians
+import org.sert2521.sertain.units.rdps
+import org.sert2521.sertain.units.revolutions
+import org.sert2521.sertain.units.rpss
+import org.sert2521.sertain.units.seconds
+import org.sert2521.sertain.units.times
+import kotlin.math.PI
 
 object Robot {
     var mode = RobotMode.DISCONNECTED

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/Encoder.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/Encoder.kt
@@ -1,14 +1,15 @@
 package org.sert2521.sertain.motors
 
 import org.sert2521.sertain.units.Angular
+import org.sert2521.sertain.units.AngularVelocity
 import org.sert2521.sertain.units.MetricUnit
-import org.sert2521.sertain.units.Seconds
+import org.sert2521.sertain.units.seconds
 import org.sert2521.sertain.units.div
 import kotlin.math.PI
 
 class Encoder(ticksPerRevolution: Int) {
     val ticks = EncoderTicks(ticksPerRevolution)
-    val ticksPerSecond = ticks / Seconds
+    val ticksPerSecond: MetricUnit<AngularVelocity> = ticks / seconds
 }
 
 class EncoderTicks(ticksPerRevolution: Int) : MetricUnit<Angular>(Angular, (PI * 2) / ticksPerRevolution, " ticks")

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/Encoder.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/Encoder.kt
@@ -1,15 +1,14 @@
 package org.sert2521.sertain.motors
 
-import org.sert2521.sertain.units.Angular
-import org.sert2521.sertain.units.AngularVelocity
-import org.sert2521.sertain.units.MetricUnit
-import org.sert2521.sertain.units.seconds
+import org.sert2521.sertain.units.AngularUnit
+import org.sert2521.sertain.units.AngularVelocityUnit
+import org.sert2521.sertain.units.Seconds
 import org.sert2521.sertain.units.div
 import kotlin.math.PI
 
 class Encoder(ticksPerRevolution: Int) {
     val ticks = EncoderTicks(ticksPerRevolution)
-    val ticksPerSecond: MetricUnit<AngularVelocity> = ticks / seconds
+    val ticksPerSecond: AngularVelocityUnit<EncoderTicks, Seconds> = ticks / Seconds
 }
 
-class EncoderTicks(ticksPerRevolution: Int) : MetricUnit<Angular>(Angular, (PI * 2) / ticksPerRevolution, " ticks")
+class EncoderTicks(ticksPerRevolution: Int) : AngularUnit((PI * 2) / ticksPerRevolution, " ticks")

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -1,13 +1,12 @@
 package org.sert2521.sertain.motors
 
-import org.sert2521.sertain.units.Angular
+import org.sert2521.sertain.units.AngularUnit
+import org.sert2521.sertain.units.AngularValue
 import org.sert2521.sertain.units.AngularVelocity
-import org.sert2521.sertain.units.Chronic
-import org.sert2521.sertain.units.CompositeUnit
-import org.sert2521.sertain.units.CompositeUnitType
-import org.sert2521.sertain.units.MetricUnit
+import org.sert2521.sertain.units.AngularVelocityUnit
+import org.sert2521.sertain.units.AngularVelocityValue
+import org.sert2521.sertain.units.ChronicUnit
 import org.sert2521.sertain.units.MetricValue
-import org.sert2521.sertain.units.Per
 import org.sert2521.sertain.units.convertTo
 import com.ctre.phoenix.motorcontrol.ControlMode as CtreControlMode
 import com.ctre.phoenix.motorcontrol.NeutralMode as CtreNeutralMode
@@ -173,13 +172,13 @@ class MotorController<T : MotorId>(
             ctreMotorController.selectedSensorPosition = value
         }
 
-    fun position(unit: MetricUnit<Angular>) =
+    fun <U : AngularUnit> position(unit: U) =
             MetricValue(encoder!!.ticks, position.toDouble()).convertTo(unit)
 
     val velocity: Int
         get() = ctreMotorController.getSelectedSensorVelocity(0)
 
-    fun velocity(unit: CompositeUnit<Per, Angular, Chronic>) =
+    fun <U1 : AngularVelocity, U2 : ChronicUnit, U : AngularVelocityUnit<U1, U2>> velocity(unit: U) =
             MetricValue(encoder!!.ticksPerSecond, velocity.toDouble()).convertTo(unit)
 
     fun setPercentOutput(output: Double) {
@@ -190,7 +189,7 @@ class MotorController<T : MotorId>(
         ctreMotorController.set(CtreControlMode.Position, position.toDouble())
     }
 
-    fun setTargetPosition(position: MetricValue<Angular>) {
+    fun <U : AngularUnit, V : AngularValue<U>> setTargetPosition(position: V) {
         checkNotNull(encoder) { "You must configure your encoder to use units." }
         setTargetPosition(position.convertTo(encoder!!.ticks).value.toInt())
     }
@@ -199,7 +198,7 @@ class MotorController<T : MotorId>(
         ctreMotorController.set(CtreControlMode.Velocity, velocity.toDouble())
     }
 
-    fun setTargetVelocity(velocity: MetricValue<AngularVelocity>) {
+    fun <U1 : AngularUnit, U2 : ChronicUnit, V : AngularVelocityValue<U1, U2>> setTargetVelocity(velocity: V) {
         checkNotNull(encoder) { "You must configure your encoder to use units." }
         setTargetVelocity(velocity.convertTo(encoder!!.ticksPerSecond).value.toInt())
     }

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -1,6 +1,7 @@
 package org.sert2521.sertain.motors
 
 import org.sert2521.sertain.units.Angular
+import org.sert2521.sertain.units.AngularVelocity
 import org.sert2521.sertain.units.Chronic
 import org.sert2521.sertain.units.CompositeUnit
 import org.sert2521.sertain.units.CompositeUnitType
@@ -189,7 +190,7 @@ class MotorController<T : MotorId>(
         ctreMotorController.set(CtreControlMode.Position, position.toDouble())
     }
 
-    fun <U : MetricUnit<Angular>> setTargetPosition(position: MetricValue<Angular, U>) {
+    fun setTargetPosition(position: MetricValue<Angular>) {
         checkNotNull(encoder) { "You must configure your encoder to use units." }
         setTargetPosition(position.convertTo(encoder!!.ticks).value.toInt())
     }
@@ -198,9 +199,7 @@ class MotorController<T : MotorId>(
         ctreMotorController.set(CtreControlMode.Velocity, velocity.toDouble())
     }
 
-    fun setTargetVelocity(
-        velocity: MetricValue<CompositeUnitType<Per, Angular, Chronic>, CompositeUnit<Per, Angular, Chronic>>
-    ) {
+    fun setTargetVelocity(velocity: MetricValue<AngularVelocity>) {
         checkNotNull(encoder) { "You must configure your encoder to use units." }
         setTargetVelocity(velocity.convertTo(encoder!!.ticksPerSecond).value.toInt())
     }

--- a/core/src/main/kotlin/org/sert2521/sertain/units/CompositeUnit.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/CompositeUnit.kt
@@ -6,13 +6,23 @@ object Per : CompositionOperation()
 object By : CompositionOperation()
 
 open class CompositeUnitType<OP : CompositionOperation, T1 : MetricUnitType, T2 : MetricUnitType>(
-    val operation: OP,
-    val type1: T1,
-    val type2: T2
+        val operation: OP,
+        val type1: T1,
+        val type2: T2
 ) : MetricUnitType()
 
-typealias CompositeUnit<OP, T1, T2> = MetricUnit<CompositeUnitType<OP, T1, T2>>
-fun <OP : CompositionOperation, T1: MetricUnitType, T2: MetricUnitType, U1 : MetricUnit<T1>, U2 : MetricUnit<T2>> compositeUnit(operation: OP, unit1: U1, unit2: U2) = CompositeUnit(
+// By operation is not well tested!
+open class CompositeUnit<
+        OP : CompositionOperation,
+        T1 : MetricUnitType,
+        T2 : MetricUnitType,
+        U1 : MetricUnit<T1>,
+        U2 : MetricUnit<T2>
+>(
+        val operation: OP,
+        val unit1: U1,
+        val unit2: U2
+) : MetricUnit<CompositeUnitType<OP, T1, T2>>(
         CompositeUnitType(operation, unit1.type, unit2.type),
         when (operation) {
             Per -> unit1.base / unit2.base
@@ -34,13 +44,18 @@ fun <OP : CompositionOperation, T1: MetricUnitType, T2: MetricUnitType, U1 : Met
         }
 )
 
-operator fun <T1 : MetricUnitType, T2 : MetricUnitType> MetricUnit<T1>.div(other: MetricUnit<T2>) =
-        compositeUnit(Per, this, other)
+operator fun <T1 : MetricUnitType, T2 : MetricUnitType, U1 : MetricUnit<T1>, U2 : MetricUnit<T2>> U1.div(other: U2) =
+        CompositeUnit(Per, this, other)
 
-operator fun <T1 : MetricUnitType, T2 : MetricUnitType> MetricUnit<T1>.times(other: MetricUnit<T2>) =
-        compositeUnit(By, this, other)
+operator fun <T1 : MetricUnitType, T2 : MetricUnitType, U1 : MetricUnit<T1>, U2 : MetricUnit<T2>> U1.times(other: U2) =
+        CompositeUnit(By, this, other)
 
 typealias Velocity = CompositeUnitType<Per, Linear, Chronic>
 typealias AngularVelocity = CompositeUnitType<Per, Angular, Chronic>
 typealias Acceleration = CompositeUnitType<Per, Linear, CompositeUnitType<By, Chronic, Chronic>>
 typealias AngularAcceleration = CompositeUnitType<Per, Angular, CompositeUnitType<By, Chronic, Chronic>>
+
+typealias VelocityUnit<U1, U2> = CompositeUnit<Per, Linear, Chronic, U1, U2>
+typealias AngularVelocityUnit<U1, U2> = CompositeUnit<Per, Angular, Chronic, U1, U2>
+typealias AccelerationUnit<U1, U2> = CompositeUnit<Per, Linear, CompositeUnitType<By, Chronic, Chronic>, U1, CompositeUnit<By, Chronic, Chronic, U2, U2>>
+typealias AngularAccelerationUnit<U1, U2> = CompositeUnit<Per, Angular, CompositeUnitType<By, Chronic, Chronic>, U1, CompositeUnit<By, Chronic, Chronic, U2, U2>>

--- a/core/src/main/kotlin/org/sert2521/sertain/units/CompositeUnit.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/CompositeUnit.kt
@@ -11,12 +11,8 @@ open class CompositeUnitType<OP : CompositionOperation, T1 : MetricUnitType, T2 
     val type2: T2
 ) : MetricUnitType()
 
-// By operation is not well tested!
-open class CompositeUnit<OP : CompositionOperation, T1 : MetricUnitType, T2 : MetricUnitType>(
-    val operation: OP,
-    val unit1: MetricUnit<T1>,
-    val unit2: MetricUnit<T2>
-) : MetricUnit<CompositeUnitType<OP, T1, T2>>(
+typealias CompositeUnit<OP, T1, T2> = MetricUnit<CompositeUnitType<OP, T1, T2>>
+fun <OP : CompositionOperation, T1: MetricUnitType, T2: MetricUnitType, U1 : MetricUnit<T1>, U2 : MetricUnit<T2>> compositeUnit(operation: OP, unit1: U1, unit2: U2) = CompositeUnit(
         CompositeUnitType(operation, unit1.type, unit2.type),
         when (operation) {
             Per -> unit1.base / unit2.base
@@ -39,7 +35,12 @@ open class CompositeUnit<OP : CompositionOperation, T1 : MetricUnitType, T2 : Me
 )
 
 operator fun <T1 : MetricUnitType, T2 : MetricUnitType> MetricUnit<T1>.div(other: MetricUnit<T2>) =
-        CompositeUnit(Per, this, other)
+        compositeUnit(Per, this, other)
 
 operator fun <T1 : MetricUnitType, T2 : MetricUnitType> MetricUnit<T1>.times(other: MetricUnit<T2>) =
-        CompositeUnit(By, this, other)
+        compositeUnit(By, this, other)
+
+typealias Velocity = CompositeUnitType<Per, Linear, Chronic>
+typealias AngularVelocity = CompositeUnitType<Per, Angular, Chronic>
+typealias Acceleration = CompositeUnitType<Per, Linear, CompositeUnitType<By, Chronic, Chronic>>
+typealias AngularAcceleration = CompositeUnitType<Per, Angular, CompositeUnitType<By, Chronic, Chronic>>

--- a/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
@@ -4,6 +4,6 @@ fun <T : MetricUnitType, U1 : MetricUnit<T>, U2 : MetricUnit<T>> Double.convert(
     return this * units.first.base / units.second.base
 }
 
-fun <T : MetricUnitType, U1 : MetricUnit<T>, U2 : MetricUnit<T>> MetricValue<T, U1>.convertTo(other: U2): MetricValue<T, U2> {
+fun <T : MetricUnitType> MetricValue<T>.convertTo(other: MetricUnit<T>): MetricValue<T> {
     return MetricValue(other, value.convert(unit to other))
 }

--- a/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
@@ -1,9 +1,7 @@
 package org.sert2521.sertain.units
 
-fun <T : MetricUnitType, U1 : MetricUnit<T>, U2 : MetricUnit<T>> Double.convert(units: Pair<U1, U2>): Double {
-    return this * units.first.base / units.second.base
-}
+fun <T : MetricUnitType, U1 : MetricUnit<T>, U2 : MetricUnit<T>> Double.convert(units: Pair<U1, U2>) =
+        this * units.first.base / units.second.base
 
-fun <T : MetricUnitType> MetricValue<T>.convertTo(other: MetricUnit<T>): MetricValue<T> {
-    return MetricValue(other, value.convert(unit to other))
-}
+fun <T : MetricUnitType, U1 : MetricUnit<T>, U2 : MetricUnit<T>> MetricValue<T, U1>.convertTo(other: U2) =
+        MetricValue(other, value.convert(unit to other))

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricUnit.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricUnit.kt
@@ -4,24 +4,20 @@ import kotlin.math.PI
 
 open class MetricUnit<T : MetricUnitType>(val type: T, val base: Double, val symbol: String)
 
-// abstract class ChronicUnit(seconds: Double, symbol: String) : MetricUnit<Chronic>(Chronic, seconds, symbol)
-typealias ChronicUnit = MetricUnit<Chronic>
-fun chronicUnit(seconds: Double, symbol: String): ChronicUnit = MetricUnit(Chronic, seconds, symbol)
+abstract class ChronicUnit(seconds: Double, symbol: String) : MetricUnit<Chronic>(Chronic, seconds, symbol)
 
-val seconds = chronicUnit(1.0, " s")
-val minutes =  chronicUnit(60.0, " min")
-val milliseconds = chronicUnit(0.001, " ms")
+object Seconds : ChronicUnit(1.0, " s")
+object Minutes : ChronicUnit(60.0, " min")
+object Milliseconds : ChronicUnit(0.001, " ms")
 
-typealias LinearUnit = MetricUnit<Linear>
-fun linearUnit(meters: Double, symbol: String): LinearUnit = MetricUnit(Linear, meters, symbol)
+abstract class LinearUnit(meters: Double, symbol: String) : MetricUnit<Linear>(Linear, meters, symbol)
 
-val meters = linearUnit(1.0, " m")
-val centimeters = linearUnit(0.01, " cm")
-val millimeters = linearUnit(0.001, " mm")
+object Meters : LinearUnit(1.0, " m")
+object Centimeters : LinearUnit(0.01, " cm")
+object Millimeters : LinearUnit(0.001, " mm")
 
-typealias AngularUnit = MetricUnit<Angular>
-fun angularUnit(radians: Double, symbol: String): AngularUnit = MetricUnit(Angular, radians, symbol)
+abstract class AngularUnit(meters: Double, symbol: String) : MetricUnit<Angular>(Angular, meters, symbol)
 
-val degrees = angularUnit(PI / 180, "°")
-val radians = angularUnit(1.0, " rad")
-val revolutions = angularUnit(PI * 2, " rev")
+object Degrees : AngularUnit(PI / 180, "°")
+object Radians : AngularUnit(1.0, " rad")
+object Revolutions : AngularUnit(PI * 2, " rev")

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricUnit.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricUnit.kt
@@ -2,22 +2,26 @@ package org.sert2521.sertain.units
 
 import kotlin.math.PI
 
-abstract class MetricUnit<T : MetricUnitType>(val type: T, val base: Double, val symbol: String)
+open class MetricUnit<T : MetricUnitType>(val type: T, val base: Double, val symbol: String)
 
-abstract class ChronicUnit(seconds: Double, symbol: String) : MetricUnit<Chronic>(Chronic, seconds, symbol)
+// abstract class ChronicUnit(seconds: Double, symbol: String) : MetricUnit<Chronic>(Chronic, seconds, symbol)
+typealias ChronicUnit = MetricUnit<Chronic>
+fun chronicUnit(seconds: Double, symbol: String): ChronicUnit = MetricUnit(Chronic, seconds, symbol)
 
-object Seconds : ChronicUnit(1.0, " s")
-object Minutes : ChronicUnit(60.0, " min")
-object Milliseconds : ChronicUnit(0.001, " ms")
+val seconds = chronicUnit(1.0, " s")
+val minutes =  chronicUnit(60.0, " min")
+val milliseconds = chronicUnit(0.001, " ms")
 
-abstract class LinearUnit(meters: Double, symbol: String) : MetricUnit<Linear>(Linear, meters, symbol)
+typealias LinearUnit = MetricUnit<Linear>
+fun linearUnit(meters: Double, symbol: String): LinearUnit = MetricUnit(Linear, meters, symbol)
 
-object Meters : LinearUnit(1.0, " m")
-object Centimeters : LinearUnit(0.01, " cm")
-object Millimeters : LinearUnit(0.001, " mm")
+val meters = linearUnit(1.0, " m")
+val centimeters = linearUnit(0.01, " cm")
+val millimeters = linearUnit(0.001, " mm")
 
-abstract class AngularUnit(radians: Double, symbol: String) : MetricUnit<Angular>(Angular, radians, symbol)
+typealias AngularUnit = MetricUnit<Angular>
+fun angularUnit(radians: Double, symbol: String): AngularUnit = MetricUnit(Angular, radians, symbol)
 
-object Degrees : AngularUnit(PI / 180, "°")
-object Radians : AngularUnit(1.0, " rad")
-object Revolutions : AngularUnit(PI * 2, " rev")
+val degrees = angularUnit(PI / 180, "°")
+val radians = angularUnit(1.0, " rad")
+val revolutions = angularUnit(PI * 2, " rev")

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
@@ -2,37 +2,37 @@ package org.sert2521.sertain.units
 
 import kotlin.math.ceil
 
-data class MetricValue<T : MetricUnitType, U : MetricUnit<T>>(val unit: U, val value: Double) {
-    override fun equals(other: Any?) = if (other is MetricValue<*, *> && unit.type == other.unit.type) {
+data class MetricValue<T : MetricUnitType>(val unit: MetricUnit<T>, val value: Double) {
+    override fun equals(other: Any?) = if (other is MetricValue<*> && unit.type == other.unit.type) {
         value * unit.base == other.value * other.unit.base
     } else {
         false
     }
 
-    operator fun <S : MetricUnit<T>> plus(other: MetricValue<T, S>) =
+    operator fun <S : MetricUnit<T>> plus(other: MetricValue<T>) =
             MetricValue(unit, value + other.convertTo(unit).value)
 
-    operator fun <S : MetricUnit<T>> minus(other: MetricValue<T, S>) =
+    operator fun <S : MetricUnit<T>> minus(other: MetricValue<T>) =
             MetricValue(unit, value - other.convertTo(unit).value)
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <R : MetricUnitType, S : MetricUnit<R>> times(other: MetricValue<*, S>) = if (unit.type == other.unit.type) {
-        MetricValue(CompositeUnit(By, unit, unit), value * (other as MetricValue<T, U>).convertTo(unit).value)
+    operator fun <T2 : MetricUnitType> times(other: MetricValue<T2>) = if (unit.type == other.unit.type) {
+        MetricValue(compositeUnit(By, unit, unit), value * (other as MetricValue<T>).convertTo(unit).value)
     } else {
-        MetricValue(CompositeUnit(By, unit, other.unit), value * other.value)
+        MetricValue(compositeUnit(By, unit, other.unit), value * other.value)
     }
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <R : MetricUnitType, S : MetricUnit<R>> div(other: MetricValue<*, S>) = if (unit.type == other.unit.type) {
-        MetricValue(CompositeUnit(Per, unit, unit), value / (other as MetricValue<T, U>).convertTo(unit).value)
+    operator fun <T2 : MetricUnitType> div(other: MetricValue<T2>) = if (unit.type == other.unit.type) {
+        MetricValue(compositeUnit(Per, unit, unit), value / (other as MetricValue<T>).convertTo(unit).value)
     } else {
-        MetricValue(CompositeUnit(Per, unit, other.unit), value / other.value)
+        MetricValue(compositeUnit(Per, unit, other.unit), value / other.value)
     }
 
-    operator fun <S : MetricUnit<T>> rem(other: MetricValue<T, S>) =
+    operator fun <S : MetricUnit<T>> rem(other: MetricValue<T>) =
             MetricValue(unit, value % other.convertTo(unit).value)
 
-    operator fun <S : MetricUnit<T>> compareTo(other: MetricValue<T, S>) =
+    operator fun <S : MetricUnit<T>> compareTo(other: MetricValue<T>) =
             ceil(value * unit.base - other.value * other.unit.base).toInt()
 
     override fun hashCode(): Int {
@@ -44,18 +44,24 @@ data class MetricValue<T : MetricUnitType, U : MetricUnit<T>>(val unit: U, val v
     override fun toString() = "$value${unit.symbol}"
 }
 
-val Number.s get() = MetricValue(Seconds, toDouble())
-val Number.min get() = MetricValue(Minutes, toDouble())
-val Number.ms get() = MetricValue(Milliseconds, toDouble())
-val Number.m get() = MetricValue(Meters, toDouble())
-val Number.cm get() = MetricValue(Centimeters, toDouble())
-val Number.mm get() = MetricValue(Millimeters, toDouble())
-val Number.deg get() = MetricValue(Degrees, toDouble())
-val Number.rad get() = MetricValue(Radians, toDouble())
-val Number.rev get() = MetricValue(Revolutions, toDouble())
-val Number.mps get() = MetricValue(Meters / Seconds, toDouble())
-val Number.mmps get() = MetricValue(Millimeters / Seconds, toDouble())
-val Number.dps get() = MetricValue(Degrees / Seconds, toDouble())
-val Number.rdps get() = MetricValue(Radians / Seconds, toDouble())
-val Number.rps get() = MetricValue(Revolutions / Seconds, toDouble())
-val Number.rpm get() = MetricValue(Revolutions / Minutes, toDouble())
+val Number.s get() = MetricValue(seconds, toDouble())
+val Number.min get() = MetricValue(minutes, toDouble())
+val Number.ms get() = MetricValue(milliseconds, toDouble())
+val Number.m get() = MetricValue(meters, toDouble())
+val Number.cm get() = MetricValue(centimeters, toDouble())
+val Number.mm get() = MetricValue(millimeters, toDouble())
+val Number.deg get() = MetricValue(degrees, toDouble())
+val Number.rad get() = MetricValue(radians, toDouble())
+val Number.rev get() = MetricValue(revolutions, toDouble())
+val Number.mps: MetricValue<Velocity> get() = MetricValue(meters / seconds, toDouble())
+val Number.mmps: MetricValue<Velocity> get() = MetricValue(millimeters / seconds, toDouble())
+val Number.dps: MetricValue<AngularVelocity> get() = MetricValue(degrees / seconds, toDouble())
+val Number.rdps: MetricValue<AngularVelocity> get() = MetricValue(radians / seconds, toDouble())
+val Number.rps: MetricValue<AngularVelocity> get() = MetricValue(revolutions / seconds, toDouble())
+val Number.rpm: MetricValue<AngularVelocity> get() = MetricValue(revolutions / minutes, toDouble())
+val Number.mpss: MetricValue<Acceleration> get() = MetricValue(meters / (seconds * seconds), toDouble())
+val Number.mmpss: MetricValue<Acceleration> get() = MetricValue(millimeters / (seconds * seconds), toDouble())
+val Number.dpss: MetricValue<AngularAcceleration> get() = MetricValue(degrees / (seconds * seconds), toDouble())
+val Number.rdpss: MetricValue<AngularAcceleration> get() = MetricValue(radians / (seconds * seconds), toDouble())
+val Number.rpss: MetricValue<AngularAcceleration> get() = MetricValue(revolutions / (seconds * seconds), toDouble())
+val Number.rpmm: MetricValue<AngularAcceleration> get() = MetricValue(revolutions / (minutes * minutes), toDouble())

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
@@ -2,37 +2,31 @@ package org.sert2521.sertain.units
 
 import kotlin.math.ceil
 
-data class MetricValue<T : MetricUnitType>(val unit: MetricUnit<T>, val value: Double) {
-    override fun equals(other: Any?) = if (other is MetricValue<*> && unit.type == other.unit.type) {
+data class MetricValue<T : MetricUnitType, U : MetricUnit<T>>(val unit: U, val value: Double) {
+    override fun equals(other: Any?) = if (other is MetricValue<*, *> && unit.type == other.unit.type) {
         value * unit.base == other.value * other.unit.base
     } else {
         false
     }
 
-    operator fun <S : MetricUnit<T>> plus(other: MetricValue<T>) =
+    operator fun plus(other: MetricValue<T, U>) =
             MetricValue(unit, value + other.convertTo(unit).value)
 
-    operator fun <S : MetricUnit<T>> minus(other: MetricValue<T>) =
+    operator fun minus(other: MetricValue<T, U>) =
             MetricValue(unit, value - other.convertTo(unit).value)
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <T2 : MetricUnitType> times(other: MetricValue<T2>) = if (unit.type == other.unit.type) {
-        MetricValue(compositeUnit(By, unit, unit), value * (other as MetricValue<T>).convertTo(unit).value)
-    } else {
-        MetricValue(compositeUnit(By, unit, other.unit), value * other.value)
-    }
+    operator fun <T2 : MetricUnitType, U2 : MetricUnit<T2>> times(other: MetricValue<T2, U2>) =
+        MetricValue(CompositeUnit(By, unit, other.unit), value * other.value)
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <T2 : MetricUnitType> div(other: MetricValue<T2>) = if (unit.type == other.unit.type) {
-        MetricValue(compositeUnit(Per, unit, unit), value / (other as MetricValue<T>).convertTo(unit).value)
-    } else {
-        MetricValue(compositeUnit(Per, unit, other.unit), value / other.value)
-    }
+    operator fun <T2 : MetricUnitType, U2 : MetricUnit<T2>> div(other: MetricValue<T2, U2>) =
+        MetricValue(CompositeUnit(Per, unit, other.unit), value / other.value)
 
-    operator fun <S : MetricUnit<T>> rem(other: MetricValue<T>) =
+    operator fun <U : MetricUnit<T>> rem(other: MetricValue<T, U>) =
             MetricValue(unit, value % other.convertTo(unit).value)
 
-    operator fun <S : MetricUnit<T>> compareTo(other: MetricValue<T>) =
+    operator fun <U : MetricUnit<T>> compareTo(other: MetricValue<T, U>) =
             ceil(value * unit.base - other.value * other.unit.base).toInt()
 
     override fun hashCode(): Int {
@@ -44,24 +38,32 @@ data class MetricValue<T : MetricUnitType>(val unit: MetricUnit<T>, val value: D
     override fun toString() = "$value${unit.symbol}"
 }
 
-val Number.s get() = MetricValue(seconds, toDouble())
-val Number.min get() = MetricValue(minutes, toDouble())
-val Number.ms get() = MetricValue(milliseconds, toDouble())
-val Number.m get() = MetricValue(meters, toDouble())
-val Number.cm get() = MetricValue(centimeters, toDouble())
-val Number.mm get() = MetricValue(millimeters, toDouble())
-val Number.deg get() = MetricValue(degrees, toDouble())
-val Number.rad get() = MetricValue(radians, toDouble())
-val Number.rev get() = MetricValue(revolutions, toDouble())
-val Number.mps: MetricValue<Velocity> get() = MetricValue(meters / seconds, toDouble())
-val Number.mmps: MetricValue<Velocity> get() = MetricValue(millimeters / seconds, toDouble())
-val Number.dps: MetricValue<AngularVelocity> get() = MetricValue(degrees / seconds, toDouble())
-val Number.rdps: MetricValue<AngularVelocity> get() = MetricValue(radians / seconds, toDouble())
-val Number.rps: MetricValue<AngularVelocity> get() = MetricValue(revolutions / seconds, toDouble())
-val Number.rpm: MetricValue<AngularVelocity> get() = MetricValue(revolutions / minutes, toDouble())
-val Number.mpss: MetricValue<Acceleration> get() = MetricValue(meters / (seconds * seconds), toDouble())
-val Number.mmpss: MetricValue<Acceleration> get() = MetricValue(millimeters / (seconds * seconds), toDouble())
-val Number.dpss: MetricValue<AngularAcceleration> get() = MetricValue(degrees / (seconds * seconds), toDouble())
-val Number.rdpss: MetricValue<AngularAcceleration> get() = MetricValue(radians / (seconds * seconds), toDouble())
-val Number.rpss: MetricValue<AngularAcceleration> get() = MetricValue(revolutions / (seconds * seconds), toDouble())
-val Number.rpmm: MetricValue<AngularAcceleration> get() = MetricValue(revolutions / (minutes * minutes), toDouble())
+typealias ChronicValue<U> = MetricValue<Chronic, U>
+typealias LinearValue<U> = MetricValue<Linear, U>
+typealias AngularValue<U> = MetricValue<Angular, U>
+typealias VelocityValue<U1, U2> = MetricValue<Velocity, VelocityUnit<U1, U2>>
+typealias AngularVelocityValue<U1, U2> = MetricValue<AngularVelocity, AngularVelocityUnit<U1, U2>>
+typealias AccelerationValue<U1, U2> = MetricValue<Acceleration, AccelerationUnit<U1, U2>>
+typealias AngularAccelerationValue<U1, U2> = MetricValue<AngularAcceleration, AngularAccelerationUnit<U1, U2>>
+
+val Number.s: ChronicValue<Seconds> get() = MetricValue(Seconds, toDouble())
+val Number.min: ChronicValue<Minutes> get() = MetricValue(Minutes, toDouble())
+val Number.ms: ChronicValue<Milliseconds> get() = MetricValue(Milliseconds, toDouble())
+val Number.m: LinearValue<Meters> get() = MetricValue(Meters, toDouble())
+val Number.cm: LinearValue<Centimeters> get() = MetricValue(Centimeters, toDouble())
+val Number.mm: LinearValue<Millimeters> get() = MetricValue(Millimeters, toDouble())
+val Number.deg: AngularValue<Degrees> get() = MetricValue(Degrees, toDouble())
+val Number.rad: AngularValue<Radians> get() = MetricValue(Radians, toDouble())
+val Number.rev: AngularValue<Revolutions> get() = MetricValue(Revolutions, toDouble())
+val Number.mps: VelocityValue<Meters, Seconds> get() = MetricValue(Meters / Seconds, toDouble())
+val Number.mmps: VelocityValue<Millimeters, Seconds> get() = MetricValue(Millimeters / Seconds, toDouble())
+val Number.dps: AngularVelocityValue<Degrees, Seconds> get() = MetricValue(Degrees / Seconds, toDouble())
+val Number.rdps: AngularVelocityValue<Radians, Seconds> get() = MetricValue(Radians / Seconds, toDouble())
+val Number.rps: AngularVelocityValue<Revolutions, Seconds> get() = MetricValue(Revolutions / Seconds, toDouble())
+val Number.rpm: AngularVelocityValue<Revolutions, Minutes> get() = MetricValue(Revolutions / Minutes, toDouble())
+val Number.mpss: AccelerationValue<Meters, Seconds> get() = MetricValue(Meters / (Seconds * Seconds), toDouble())
+val Number.mmpss: AccelerationValue<Millimeters, Seconds> get() = MetricValue(Millimeters / (Seconds * Seconds), toDouble())
+val Number.dpss: AngularAccelerationValue<Degrees, Seconds> get() = MetricValue(Degrees / (Seconds * Seconds), toDouble())
+val Number.rdpss: AngularAccelerationValue<Radians, Seconds> get() = MetricValue(Radians / (Seconds * Seconds), toDouble())
+val Number.rpss: AngularAccelerationValue<Revolutions, Seconds> get() = MetricValue(Revolutions / (Seconds * Seconds), toDouble())
+val Number.rpmm: AngularAccelerationValue<Revolutions, Minutes> get() = MetricValue(Revolutions / (Minutes * Minutes), toDouble())


### PR DESCRIPTION
Units work, but they are incredibly inconvenient to use. The type signatures produced by composite units are absolutely atrocious to look at. This basically changes units to use type aliases as a way to shrink down horrible type signatures, and also just simplifies the framework in general.