### PR TITLE
Fix laggy linkTableEntry

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -2,7 +2,7 @@ package org.sert2521.sertain.subsystems
 
 import kotlinx.coroutines.Job
 
-abstract class Subsystem(val name: String = "Anonymous Subsystem", val default: (suspend () -> Unit)? = null) {
+abstract class Subsystem(val name: String = "Anonymous Subsystem", val default: (suspend () -> Any?)? = null) {
     var isEnabled = true
 
     internal var currentJob: Job? = null

--- a/core/src/main/kotlin/org/sert2521/sertain/telemetry/Utils.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/telemetry/Utils.kt
@@ -2,22 +2,19 @@ package org.sert2521.sertain.telemetry
 
 import kotlinx.coroutines.CoroutineScope
 import org.sert2521.sertain.coroutines.watch
+import org.sert2521.sertain.events.onTick
 
 fun <T> CoroutineScope.linkTableEntry(name: String, parent: Table, get: () -> T) = run {
     val entry = TableEntry(name, get(), parent)
-    get.watch {
-        onChange {
-            entry.value = value
-        }
+    onTick {
+        entry.value = get()
     }
 }
 
 fun <T> CoroutineScope.linkTableEntry(name: String, vararg location: String, get: () -> T) = run {
     val entry = TableEntry(name, get(), *location)
-    get.watch {
-        onChange {
-            entry.value = value
-        }
+    onTick {
+        entry.value = get()
     }
 }
 


### PR DESCRIPTION
`linkTableEntry` was causing a lot of lag. This fixes it by using `onTick` instead of an observable value.