### PR TITLE
Subsystem fixes

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,7 +30,11 @@ tasks.withType<KotlinCompile> {
 val compileKotlin: KotlinCompile by tasks
 
 compileKotlin.kotlinOptions {
-    freeCompilerArgs = listOf("-XXLanguage:+InlineClasses", "-Xuse-experimental=kotlin.Experimental")
+    freeCompilerArgs = listOf(
+            "-XXLanguage:+InlineClasses",
+            "-Xuse-experimental=kotlin.Experimental",
+            "-Xallow-result-return-type"
+    )
 }
 
 publishing {

--- a/core/src/main/kotlin/org/sert2521/sertain/control/PidfController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/control/PidfController.kt
@@ -1,5 +1,7 @@
 package org.sert2521.sertain.control
 
+import kotlin.math.sign
+
 open class PidfConfig {
     var kp: Double? = null
     var ki: Double? = null
@@ -21,6 +23,6 @@ class PidfController(config: PidfConfig, val dt: Double) {
         integral += error * dt
         val derivative = (error - lastError) / dt
         lastError = error
-        return (kp * error) + (ki * integral) + (kd * derivative) + kf
+        return (kp * error) + (ki * integral) + (kd * derivative) + (kf * sign(error))
     }
 }

--- a/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
@@ -13,7 +13,7 @@ class Use<R>(
     val cancelConflicts: Boolean,
     val name: String,
     val context: CoroutineContext,
-    val continuation: CancellableContinuation<R>,
+    val continuation: CancellableContinuation<Result<R>>,
     val action: suspend CoroutineScope.() -> R
 ) : SubsystemEvent
 

--- a/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/SubsystemEvent.kt
@@ -8,7 +8,7 @@ import kotlin.coroutines.CoroutineContext
 
 interface SubsystemEvent : Event
 
-class Use<R>(
+data class Use<R>(
     val subsystems: Set<Subsystem>,
     val cancelConflicts: Boolean,
     val name: String,
@@ -17,7 +17,7 @@ class Use<R>(
     val action: suspend CoroutineScope.() -> R
 ) : SubsystemEvent
 
-class Clean(
+data class Clean(
     val subsystems: Set<Subsystem>,
     val job: Job
 ) : SubsystemEvent

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -2,7 +2,7 @@ package org.sert2521.sertain.subsystems
 
 import kotlinx.coroutines.Job
 
-abstract class Subsystem(val name: String = "Anonymous Subsystem", val default: (suspend () -> Unit)? = null) {
+abstract class Subsystem(val name: String = "Anonymous Subsystem", val default: (suspend () -> Any?)? = null) {
     var isEnabled = true
 
     internal var currentJob: Job? = null

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystem.kt
@@ -2,7 +2,7 @@ package org.sert2521.sertain.subsystems
 
 import kotlinx.coroutines.Job
 
-abstract class Subsystem(val name: String, val default: (suspend () -> Unit)? = null) {
+abstract class Subsystem(val name: String = "Anonymous Subsystem", val default: (suspend () -> Unit)? = null) {
     var isEnabled = true
 
     internal var currentJob: Job? = null

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystems.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Subsystems.kt
@@ -1,5 +1,6 @@
 package org.sert2521.sertain.subsystems
 
+import kotlinx.coroutines.CoroutineScope
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
 
@@ -28,8 +29,15 @@ fun <S : Subsystem> access(reference: KClass<S>): S {
 
 inline fun <reified S : Subsystem> access() = access(S::class)
 
-inline fun <reified S : Subsystem> TaskConfigure.use(): S {
-    val subsystem = access(S::class)
-    this += subsystem
-    return subsystem
+data class Accessor<S : Subsystem>(
+        internal val getSubsystem: () -> S
+) {
+    suspend operator fun <R> invoke(action: suspend CoroutineScope.(subsystem: S) -> R) = use(this, action = action)
+
+    fun access() = getSubsystem()
+}
+
+inline fun <reified S : Subsystem> register(): Accessor<S> {
+    add<S>()
+    return Accessor(::access)
 }

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/TaskManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/TaskManager.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.sert2521.sertain.coroutines.RobotScope
@@ -66,11 +67,14 @@ fun CoroutineScope.manageTasks() {
                     }
                 }
 
-                val result = coroutineScope { use.action(this) }
 
-                use.continuation.resume(result)
+                val result = coroutineScope {
+                    use.action(this)
+                }
+
+                use.continuation.resume(Result.success(result))
             } catch (e: Throwable) {
-                use.continuation.resumeWithException(e)
+                use.continuation.resume(Result.failure(e))
             } finally {
                 fire(Clean(newSubsystems, coroutineContext[Job]!!))
             }

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/TaskManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/TaskManager.kt
@@ -15,7 +15,6 @@ import org.sert2521.sertain.events.Clean
 import org.sert2521.sertain.events.Use
 import org.sert2521.sertain.events.fire
 import org.sert2521.sertain.events.subscribe
-import java.lang.IllegalStateException
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/TaskManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/TaskManager.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -14,6 +15,7 @@ import org.sert2521.sertain.events.Clean
 import org.sert2521.sertain.events.Use
 import org.sert2521.sertain.events.fire
 import org.sert2521.sertain.events.subscribe
+import java.lang.IllegalStateException
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
@@ -81,6 +83,13 @@ fun CoroutineScope.manageTasks() {
         }
 
         newSubsystems.forEach { it.currentJob = newJob }
+
+        // Double check that there are no conflicts
+        delay(1)
+        if (allSubsystems.any { it.currentJob != newJob }) {
+            newJob.cancel("Action ${use.name} was canceled because another action " +
+                    "requiring one or more of the same subsystems is already running.")
+        }
     }
 
     subscribe<Clean> { clean ->

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/TaskManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/TaskManager.kt
@@ -22,6 +22,8 @@ import kotlin.coroutines.resumeWithException
 
 fun CoroutineScope.manageTasks() {
     subscribe<Use<Any?>> { use ->
+        delay(1)
+        
         // Subsystems used in parent coroutine
         val prevSubsystems: Set<Subsystem> = use.context[Requirements] ?: emptySet()
         // Subsystems used in new coroutine but not in parent coroutine
@@ -67,7 +69,6 @@ fun CoroutineScope.manageTasks() {
                         it.join()
                     }
                 }
-
 
                 val result = coroutineScope {
                     use.action(this)

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/TaskManager.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/TaskManager.kt
@@ -66,11 +66,7 @@ fun CoroutineScope.manageTasks() {
                     }
                 }
 
-                val result = coroutineScope {
-                    launch {
-                        use.action(this)
-                    }
-                }
+                val result = coroutineScope { use.action(this) }
 
                 use.continuation.resume(result)
             } catch (e: Throwable) {

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Tasks.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Tasks.kt
@@ -34,8 +34,9 @@ suspend fun <R> use(
     cancelConflicts: Boolean = true,
     name: String = "ANONYMOUS_TASK",
     action: suspend CoroutineScope.() -> R
-): R {
+): Result<R> {
     val context = coroutineContext
+    println("Calling use!")
     return suspendCancellableCoroutine { continuation ->
         CoroutineScope(context).launch {
             fire(Use(

--- a/core/src/main/kotlin/org/sert2521/sertain/subsystems/Tasks.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/subsystems/Tasks.kt
@@ -7,28 +7,27 @@ import org.sert2521.sertain.events.Use
 import org.sert2521.sertain.events.fire
 import kotlin.coroutines.coroutineContext
 
-class TaskConfigure {
-    internal val subsystems = mutableListOf<Subsystem>()
+suspend fun <S1 : Subsystem, R> use(s1: Accessor<S1>, cancelConflicts: Boolean = true, name: String = "Anonymous Task", action: suspend CoroutineScope.(S1) -> R) =
+        use(s1.access(), cancelConflicts = cancelConflicts, name = name) { action(s1.access()) }
+suspend fun <S1 : Subsystem, S2 : Subsystem, R> use(s1: Accessor<S1>, s2: Accessor<S2>, cancelConflicts: Boolean = true, name: String = "Anonymous Task", action: suspend CoroutineScope.(S1, S2) -> R) =
+        use(s1.access(), s2.access(), cancelConflicts = cancelConflicts, name = name) { action(s1.access(), s2.access()) }
+suspend fun <S1 : Subsystem, S2 : Subsystem, S3 : Subsystem, R> use(s1: Accessor<S1>, s2: Accessor<S2>, s3: Accessor<S3>, cancelConflicts: Boolean = true, name: String = "Anonymous Task", action: suspend CoroutineScope.(S1, S2, S3) -> R) =
+        use(s1.access(), s2.access(), s3.access(), cancelConflicts = cancelConflicts, name = name) { action(s1.access(), s2.access(), s3.access()) }
+suspend fun <S1 : Subsystem, S2 : Subsystem, S3 : Subsystem, S4 : Subsystem, R> use(s1: Accessor<S1>, s2: Accessor<S2>, s3: Accessor<S3>, s4: Accessor<S4>, cancelConflicts: Boolean = true, name: String = "Anonymous Task", action: suspend CoroutineScope.(S1, S2, S3, S4) -> R) =
+        use(s1.access(), s2.access(), s3.access(), s4.access(), cancelConflicts = cancelConflicts, name = name) { action(s1.access(), s2.access(), s3.access(), s4.access()) }
+suspend fun <S1 : Subsystem, S2 : Subsystem, S3 : Subsystem, S4 : Subsystem, S5 : Subsystem, R> use(s1: Accessor<S1>, s2: Accessor<S2>, s3: Accessor<S3>, s4: Accessor<S4>, s5: Accessor<S5>, cancelConflicts: Boolean = true, name: String = "Anonymous Task", action: suspend CoroutineScope.(S1, S2, S3, S4, S5) -> R) =
+        use(s1.access(), s2.access(), s3.access(), s4.access(), s5.access(), cancelConflicts = cancelConflicts, name = name) { action(s1.access(), s2.access(), s3.access(), s4.access(), s5.access()) }
+suspend fun <S1 : Subsystem, S2 : Subsystem, S3 : Subsystem, S4 : Subsystem, S5 : Subsystem, S6 : Subsystem, R> use(s1: Accessor<S1>, s2: Accessor<S2>, s3: Accessor<S3>, s4: Accessor<S4>, s5: Accessor<S5>, s6: Accessor<S6>, cancelConflicts: Boolean = true, name: String = "Anonymous Task", action: suspend CoroutineScope.(S1, S2, S3, S4, S5, S6) -> R) =
+        use(s1.access(), s2.access(), s3.access(), s4.access(), s5.access(), s6.access(), cancelConflicts = cancelConflicts, name = name) { action(s1.access(), s2.access(), s3.access(), s4.access(), s5.access(), s6.access()) }
+suspend fun <S1 : Subsystem, S2 : Subsystem, S3 : Subsystem, S4 : Subsystem, S5 : Subsystem, S6 : Subsystem, S7 : Subsystem, R> use(s1: Accessor<S1>, s2: Accessor<S2>, s3: Accessor<S3>, s4: Accessor<S4>, s5: Accessor<S5>, s6: Accessor<S6>, s7: Accessor<S7>, cancelConflicts: Boolean = true, name: String = "Anonymous Task", action: suspend CoroutineScope.(S1, S2, S3, S4, S5, S6, S7) -> R) =
+        use(s1.access(), s2.access(), s3.access(), s4.access(), s5.access(), s6.access(), s7.access(), cancelConflicts = cancelConflicts, name = name) { action(s1.access(), s2.access(), s3.access(), s4.access(), s5.access(), s6.access(), s7.access()) }
+suspend fun <S1 : Subsystem, S2 : Subsystem, S3 : Subsystem, S4 : Subsystem, S5 : Subsystem, S6 : Subsystem, S7 : Subsystem, S8 : Subsystem, R> use(s1: Accessor<S1>, s2: Accessor<S2>, s3: Accessor<S3>, s4: Accessor<S4>, s5: Accessor<S5>, s6: Accessor<S6>, s7: Accessor<S7>, s8: Accessor<S8>, cancelConflicts: Boolean = true, name: String = "Anonymous Task", action: suspend CoroutineScope.(S1, S2, S3, S4, S5, S6, S7, S8) -> R) =
+        use(s1.access(), s2.access(), s3.access(), s4.access(), s5.access(), s6.access(), s7.access(), s8.access(), cancelConflicts = cancelConflicts, name = name) { action(s1.access(), s2.access(), s3.access(), s4.access(), s5.access(), s6.access(), s7.access(), s8.access()) }
 
-    operator fun plusAssign(subsystem: Subsystem) {
-        subsystems += subsystem
-    }
-
-    internal var action: (suspend CoroutineScope.() -> Unit) = {}
-
-    fun action(action: suspend CoroutineScope.() -> Unit) {
-        this.action = action
-    }
-}
-
-suspend fun doTask(name: String = "ANONYMOUS_TASK", configure: TaskConfigure.() -> Unit) {
-    with(TaskConfigure().apply(configure)) {
-        action.let {
-            @Suppress("unchecked_cast") // Will work, ActionConfigure extends CoroutineScope
-            (use(*subsystems.toTypedArray(), name = name, action = it))
-        }
-    }
-}
+suspend fun reserve(vararg subsystems: Accessor<*>) =
+        use(*subsystems.map { it.access() }.toTypedArray()) {}
+suspend fun <R> reserve(vararg subsystems: Accessor<*>, action: suspend CoroutineScope.() -> R) =
+    use(*subsystems.map { it.access() }.toTypedArray()) { action() }
 
 suspend fun <R> use(
     vararg subsystems: Subsystem,

--- a/core/src/main/kotlin/org/sert2521/sertain/telemetry/Utils.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/telemetry/Utils.kt
@@ -2,22 +2,19 @@ package org.sert2521.sertain.telemetry
 
 import kotlinx.coroutines.CoroutineScope
 import org.sert2521.sertain.coroutines.watch
+import org.sert2521.sertain.events.onTick
 
 fun <T> CoroutineScope.linkTableEntry(name: String, parent: Table, get: () -> T) = run {
     val entry = TableEntry(name, get(), parent)
-    get.watch {
-        onChange {
-            entry.value = value
-        }
+    onTick {
+        entry.value = get()
     }
 }
 
 fun <T> CoroutineScope.linkTableEntry(name: String, vararg location: String, get: () -> T) = run {
     val entry = TableEntry(name, get(), *location)
-    get.watch {
-        onChange {
-            entry.value = value
-        }
+    onTick {
+        entry.value = get()
     }
 }
 


### PR DESCRIPTION
The subsystem update caused some unexpected issues. Cancelling the command internally using `cancel` caused it to crash. This was avoided in the old version by wrapping the task in `launch`, but this also prevented a value from being returned from tasks. To solve this `use` now returns a `Result` containing the return value of your task. Create the task like usual:
```
suspend fun someTask() = subbySystem {
    delay(1000)
    cancel()
}
```
You can then call the function and use the return value like so:
```
val result = someTask().onSuccess {
    // Is called if the function returns normally
}.onFailure {
    // Is called if function is canceled prematurely
}
```
Note that just because `cancel` returns a failure does not mean that it should not be used. You only need to worry about avoiding `cancel` if you need the return value of the task.