### PR TITLE
Unit reforms

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/motors/Encoder.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/Encoder.kt
@@ -1,14 +1,16 @@
 package org.sert2521.sertain.motors
 
-import org.sert2521.sertain.units.AngularUnit
+import org.sert2521.sertain.units.AngularVelocity
 import org.sert2521.sertain.units.AngularVelocityUnit
-import org.sert2521.sertain.units.Seconds
+import org.sert2521.sertain.units.MetricUnit
+import org.sert2521.sertain.units.angularUnit
 import org.sert2521.sertain.units.div
+import org.sert2521.sertain.units.seconds
 import kotlin.math.PI
 
 class Encoder(ticksPerRevolution: Int) {
-    val ticks = EncoderTicks(ticksPerRevolution)
-    val ticksPerSecond: AngularVelocityUnit<EncoderTicks, Seconds> = ticks / Seconds
+    val ticks = encoderTicks(ticksPerRevolution)
+    val ticksPerSecond: AngularVelocityUnit = ticks / seconds
 }
 
-class EncoderTicks(ticksPerRevolution: Int) : AngularUnit((PI * 2) / ticksPerRevolution, " ticks")
+fun encoderTicks(ticksPerRevolution: Int) = angularUnit((PI * 2) / ticksPerRevolution, " ticks")

--- a/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/motors/MotorController.kt
@@ -1,11 +1,9 @@
 package org.sert2521.sertain.motors
 
+import org.sert2521.sertain.units.Angular
 import org.sert2521.sertain.units.AngularUnit
-import org.sert2521.sertain.units.AngularValue
 import org.sert2521.sertain.units.AngularVelocity
 import org.sert2521.sertain.units.AngularVelocityUnit
-import org.sert2521.sertain.units.AngularVelocityValue
-import org.sert2521.sertain.units.ChronicUnit
 import org.sert2521.sertain.units.MetricValue
 import org.sert2521.sertain.units.convertTo
 import com.ctre.phoenix.motorcontrol.ControlMode as CtreControlMode
@@ -172,13 +170,13 @@ class MotorController<T : MotorId>(
             ctreMotorController.selectedSensorPosition = value
         }
 
-    fun <U : AngularUnit> position(unit: U) =
+    fun position(unit: AngularUnit) =
             MetricValue(encoder!!.ticks, position.toDouble()).convertTo(unit)
 
     val velocity: Int
         get() = ctreMotorController.getSelectedSensorVelocity(0)
 
-    fun <U1 : AngularVelocity, U2 : ChronicUnit, U : AngularVelocityUnit<U1, U2>> velocity(unit: U) =
+    fun velocity(unit: AngularVelocityUnit) =
             MetricValue(encoder!!.ticksPerSecond, velocity.toDouble()).convertTo(unit)
 
     fun setPercentOutput(output: Double) {
@@ -189,7 +187,7 @@ class MotorController<T : MotorId>(
         ctreMotorController.set(CtreControlMode.Position, position.toDouble())
     }
 
-    fun <U : AngularUnit, V : AngularValue<U>> setTargetPosition(position: V) {
+    fun setTargetPosition(position: MetricValue<Angular>) {
         checkNotNull(encoder) { "You must configure your encoder to use units." }
         setTargetPosition(position.convertTo(encoder!!.ticks).value.toInt())
     }
@@ -198,7 +196,7 @@ class MotorController<T : MotorId>(
         ctreMotorController.set(CtreControlMode.Velocity, velocity.toDouble())
     }
 
-    fun <U1 : AngularUnit, U2 : ChronicUnit, V : AngularVelocityValue<U1, U2>> setTargetVelocity(velocity: V) {
+    fun setTargetVelocity(velocity: MetricValue<AngularVelocity>) {
         checkNotNull(encoder) { "You must configure your encoder to use units." }
         setTargetVelocity(velocity.convertTo(encoder!!.ticksPerSecond).value.toInt())
     }

--- a/core/src/main/kotlin/org/sert2521/sertain/units/CompositeUnit.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/CompositeUnit.kt
@@ -1,3 +1,4 @@
+
 package org.sert2521.sertain.units
 
 sealed class CompositionOperation
@@ -11,18 +12,8 @@ open class CompositeUnitType<OP : CompositionOperation, T1 : MetricUnitType, T2 
         val type2: T2
 ) : MetricUnitType()
 
-// By operation is not well tested!
-open class CompositeUnit<
-        OP : CompositionOperation,
-        T1 : MetricUnitType,
-        T2 : MetricUnitType,
-        U1 : MetricUnit<T1>,
-        U2 : MetricUnit<T2>
->(
-        val operation: OP,
-        val unit1: U1,
-        val unit2: U2
-) : MetricUnit<CompositeUnitType<OP, T1, T2>>(
+typealias CompositeUnit<OP, T1, T2> = MetricUnit<CompositeUnitType<OP, T1, T2>>
+fun <OP : CompositionOperation, T1: MetricUnitType, T2: MetricUnitType, U1 : MetricUnit<T1>, U2 : MetricUnit<T2>> compositeUnit(operation: OP, unit1: U1, unit2: U2) = CompositeUnit(
         CompositeUnitType(operation, unit1.type, unit2.type),
         when (operation) {
             Per -> unit1.base / unit2.base
@@ -44,18 +35,18 @@ open class CompositeUnit<
         }
 )
 
-operator fun <T1 : MetricUnitType, T2 : MetricUnitType, U1 : MetricUnit<T1>, U2 : MetricUnit<T2>> U1.div(other: U2) =
-        CompositeUnit(Per, this, other)
+operator fun <T1 : MetricUnitType, T2 : MetricUnitType> MetricUnit<T1>.div(other: MetricUnit<T2>) =
+        compositeUnit(Per, this, other)
 
-operator fun <T1 : MetricUnitType, T2 : MetricUnitType, U1 : MetricUnit<T1>, U2 : MetricUnit<T2>> U1.times(other: U2) =
-        CompositeUnit(By, this, other)
+operator fun <T1 : MetricUnitType, T2 : MetricUnitType> MetricUnit<T1>.times(other: MetricUnit<T2>) =
+        compositeUnit(By, this, other)
 
 typealias Velocity = CompositeUnitType<Per, Linear, Chronic>
 typealias AngularVelocity = CompositeUnitType<Per, Angular, Chronic>
 typealias Acceleration = CompositeUnitType<Per, Linear, CompositeUnitType<By, Chronic, Chronic>>
 typealias AngularAcceleration = CompositeUnitType<Per, Angular, CompositeUnitType<By, Chronic, Chronic>>
 
-typealias VelocityUnit<U1, U2> = CompositeUnit<Per, Linear, Chronic, U1, U2>
-typealias AngularVelocityUnit<U1, U2> = CompositeUnit<Per, Angular, Chronic, U1, U2>
-typealias AccelerationUnit<U1, U2> = CompositeUnit<Per, Linear, CompositeUnitType<By, Chronic, Chronic>, U1, CompositeUnit<By, Chronic, Chronic, U2, U2>>
-typealias AngularAccelerationUnit<U1, U2> = CompositeUnit<Per, Angular, CompositeUnitType<By, Chronic, Chronic>, U1, CompositeUnit<By, Chronic, Chronic, U2, U2>>
+typealias VelocityUnit = MetricUnit<Velocity>
+typealias AngularVelocityUnit = MetricUnit<AngularVelocity>
+typealias AccelerationUnit = MetricUnit<Acceleration>
+typealias AngularAccelerationUnit = MetricUnit<AngularAcceleration>

--- a/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
@@ -1,6 +1,7 @@
 package org.sert2521.sertain.units
 
 fun <T : MetricUnitType, U1 : MetricUnit<T>, U2 : MetricUnit<T>> Double.convert(units: Pair<U1, U2>): Double {
+    if (units.first == units.second) return this
     return this * units.first.base / units.second.base
 }
 
@@ -8,6 +9,6 @@ fun <T : MetricUnitType> MetricValue<T>.convertTo(other: MetricUnit<T>): MetricV
     return MetricValue(other, value.convert(unit to other))
 }
 
-fun <T : MetricUnitType> MetricValue<T>.from(other: MetricUnit<T>): Double {
+infix fun <T : MetricUnitType> MetricValue<T>.from(other: MetricUnit<T>): Double {
     return value.convert(unit to other)
 }

--- a/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
@@ -7,3 +7,7 @@ fun <T : MetricUnitType, U1 : MetricUnit<T>, U2 : MetricUnit<T>> Double.convert(
 fun <T : MetricUnitType> MetricValue<T>.convertTo(other: MetricUnit<T>): MetricValue<T> {
     return MetricValue(other, value.convert(unit to other))
 }
+
+fun <T : MetricUnitType> MetricValue<T>.from(other: MetricUnit<T>): Double {
+    return value.convert(unit to other)
+}

--- a/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
@@ -9,6 +9,6 @@ fun <T : MetricUnitType> MetricValue<T>.convertTo(other: MetricUnit<T>): MetricV
     return MetricValue(other, value.convert(unit to other))
 }
 
-infix fun <T : MetricUnitType> MetricValue<T>.from(other: MetricUnit<T>): Double {
+fun <T : MetricUnitType> MetricValue<T>.from(other: MetricUnit<T>): Double {
     return value.convert(unit to other)
 }

--- a/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/Conversions.kt
@@ -1,7 +1,9 @@
 package org.sert2521.sertain.units
 
-fun <T : MetricUnitType, U1 : MetricUnit<T>, U2 : MetricUnit<T>> Double.convert(units: Pair<U1, U2>) =
-        this * units.first.base / units.second.base
+fun <T : MetricUnitType, U1 : MetricUnit<T>, U2 : MetricUnit<T>> Double.convert(units: Pair<U1, U2>): Double {
+    return this * units.first.base / units.second.base
+}
 
-fun <T : MetricUnitType, U1 : MetricUnit<T>, U2 : MetricUnit<T>> MetricValue<T, U1>.convertTo(other: U2) =
-        MetricValue(other, value.convert(unit to other))
+fun <T : MetricUnitType> MetricValue<T>.convertTo(other: MetricUnit<T>): MetricValue<T> {
+    return MetricValue(other, value.convert(unit to other))
+}

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricUnit.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricUnit.kt
@@ -4,20 +4,25 @@ import kotlin.math.PI
 
 open class MetricUnit<T : MetricUnitType>(val type: T, val base: Double, val symbol: String)
 
-abstract class ChronicUnit(seconds: Double, symbol: String) : MetricUnit<Chronic>(Chronic, seconds, symbol)
+// abstract class ChronicUnit(seconds: Double, symbol: String) : MetricUnit<Chronic>(Chronic, seconds, symbol)
+typealias ChronicUnit = MetricUnit<Chronic>
+fun chronicUnit(seconds: Double, symbol: String): ChronicUnit = MetricUnit(Chronic, seconds, symbol)
 
-object Seconds : ChronicUnit(1.0, " s")
-object Minutes : ChronicUnit(60.0, " min")
-object Milliseconds : ChronicUnit(0.001, " ms")
+val seconds = chronicUnit(1.0, " s")
+val minutes =  chronicUnit(60.0, " min")
+val milliseconds = chronicUnit(0.001, " ms")
 
-abstract class LinearUnit(meters: Double, symbol: String) : MetricUnit<Linear>(Linear, meters, symbol)
+typealias LinearUnit = MetricUnit<Linear>
+fun linearUnit(meters: Double, symbol: String): LinearUnit = MetricUnit(Linear, meters, symbol)
 
-object Meters : LinearUnit(1.0, " m")
-object Centimeters : LinearUnit(0.01, " cm")
-object Millimeters : LinearUnit(0.001, " mm")
+val meters = linearUnit(1.0, " m")
+val centimeters = linearUnit(0.01, " cm")
+val millimeters = linearUnit(0.001, " mm")
 
-abstract class AngularUnit(meters: Double, symbol: String) : MetricUnit<Angular>(Angular, meters, symbol)
+typealias AngularUnit = MetricUnit<Angular>
+fun angularUnit(radians: Double, symbol: String): AngularUnit = MetricUnit(Angular, radians, symbol)
 
-object Degrees : AngularUnit(PI / 180, "°")
-object Radians : AngularUnit(1.0, " rad")
-object Revolutions : AngularUnit(PI * 2, " rev")
+val degrees = angularUnit(PI / 180, "°")
+val radians = angularUnit(1.0, " rad")
+val revolutions = angularUnit(PI * 2, " rev")
+

--- a/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/units/MetricValue.kt
@@ -2,31 +2,37 @@ package org.sert2521.sertain.units
 
 import kotlin.math.ceil
 
-data class MetricValue<T : MetricUnitType, U : MetricUnit<T>>(val unit: U, val value: Double) {
-    override fun equals(other: Any?) = if (other is MetricValue<*, *> && unit.type == other.unit.type) {
+data class MetricValue<T : MetricUnitType>(val unit: MetricUnit<T>, val value: Double) {
+    override fun equals(other: Any?) = if (other is MetricValue<*> && unit.type == other.unit.type) {
         value * unit.base == other.value * other.unit.base
     } else {
         false
     }
 
-    operator fun plus(other: MetricValue<T, U>) =
+    operator fun <S : MetricUnit<T>> plus(other: MetricValue<T>) =
             MetricValue(unit, value + other.convertTo(unit).value)
 
-    operator fun minus(other: MetricValue<T, U>) =
+    operator fun <S : MetricUnit<T>> minus(other: MetricValue<T>) =
             MetricValue(unit, value - other.convertTo(unit).value)
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <T2 : MetricUnitType, U2 : MetricUnit<T2>> times(other: MetricValue<T2, U2>) =
-        MetricValue(CompositeUnit(By, unit, other.unit), value * other.value)
+    operator fun <T2 : MetricUnitType> times(other: MetricValue<T2>) = if (unit.type == other.unit.type) {
+        MetricValue(compositeUnit(By, unit, unit), value * (other as MetricValue<T>).convertTo(unit).value)
+    } else {
+        MetricValue(compositeUnit(By, unit, other.unit), value * other.value)
+    }
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <T2 : MetricUnitType, U2 : MetricUnit<T2>> div(other: MetricValue<T2, U2>) =
-        MetricValue(CompositeUnit(Per, unit, other.unit), value / other.value)
+    operator fun <T2 : MetricUnitType> div(other: MetricValue<T2>) = if (unit.type == other.unit.type) {
+        MetricValue(compositeUnit(Per, unit, unit), value / (other as MetricValue<T>).convertTo(unit).value)
+    } else {
+        MetricValue(compositeUnit(Per, unit, other.unit), value / other.value)
+    }
 
-    operator fun <U : MetricUnit<T>> rem(other: MetricValue<T, U>) =
+    operator fun <S : MetricUnit<T>> rem(other: MetricValue<T>) =
             MetricValue(unit, value % other.convertTo(unit).value)
 
-    operator fun <U : MetricUnit<T>> compareTo(other: MetricValue<T, U>) =
+    operator fun <S : MetricUnit<T>> compareTo(other: MetricValue<T>) =
             ceil(value * unit.base - other.value * other.unit.base).toInt()
 
     override fun hashCode(): Int {
@@ -38,32 +44,24 @@ data class MetricValue<T : MetricUnitType, U : MetricUnit<T>>(val unit: U, val v
     override fun toString() = "$value${unit.symbol}"
 }
 
-typealias ChronicValue<U> = MetricValue<Chronic, U>
-typealias LinearValue<U> = MetricValue<Linear, U>
-typealias AngularValue<U> = MetricValue<Angular, U>
-typealias VelocityValue<U1, U2> = MetricValue<Velocity, VelocityUnit<U1, U2>>
-typealias AngularVelocityValue<U1, U2> = MetricValue<AngularVelocity, AngularVelocityUnit<U1, U2>>
-typealias AccelerationValue<U1, U2> = MetricValue<Acceleration, AccelerationUnit<U1, U2>>
-typealias AngularAccelerationValue<U1, U2> = MetricValue<AngularAcceleration, AngularAccelerationUnit<U1, U2>>
-
-val Number.s: ChronicValue<Seconds> get() = MetricValue(Seconds, toDouble())
-val Number.min: ChronicValue<Minutes> get() = MetricValue(Minutes, toDouble())
-val Number.ms: ChronicValue<Milliseconds> get() = MetricValue(Milliseconds, toDouble())
-val Number.m: LinearValue<Meters> get() = MetricValue(Meters, toDouble())
-val Number.cm: LinearValue<Centimeters> get() = MetricValue(Centimeters, toDouble())
-val Number.mm: LinearValue<Millimeters> get() = MetricValue(Millimeters, toDouble())
-val Number.deg: AngularValue<Degrees> get() = MetricValue(Degrees, toDouble())
-val Number.rad: AngularValue<Radians> get() = MetricValue(Radians, toDouble())
-val Number.rev: AngularValue<Revolutions> get() = MetricValue(Revolutions, toDouble())
-val Number.mps: VelocityValue<Meters, Seconds> get() = MetricValue(Meters / Seconds, toDouble())
-val Number.mmps: VelocityValue<Millimeters, Seconds> get() = MetricValue(Millimeters / Seconds, toDouble())
-val Number.dps: AngularVelocityValue<Degrees, Seconds> get() = MetricValue(Degrees / Seconds, toDouble())
-val Number.rdps: AngularVelocityValue<Radians, Seconds> get() = MetricValue(Radians / Seconds, toDouble())
-val Number.rps: AngularVelocityValue<Revolutions, Seconds> get() = MetricValue(Revolutions / Seconds, toDouble())
-val Number.rpm: AngularVelocityValue<Revolutions, Minutes> get() = MetricValue(Revolutions / Minutes, toDouble())
-val Number.mpss: AccelerationValue<Meters, Seconds> get() = MetricValue(Meters / (Seconds * Seconds), toDouble())
-val Number.mmpss: AccelerationValue<Millimeters, Seconds> get() = MetricValue(Millimeters / (Seconds * Seconds), toDouble())
-val Number.dpss: AngularAccelerationValue<Degrees, Seconds> get() = MetricValue(Degrees / (Seconds * Seconds), toDouble())
-val Number.rdpss: AngularAccelerationValue<Radians, Seconds> get() = MetricValue(Radians / (Seconds * Seconds), toDouble())
-val Number.rpss: AngularAccelerationValue<Revolutions, Seconds> get() = MetricValue(Revolutions / (Seconds * Seconds), toDouble())
-val Number.rpmm: AngularAccelerationValue<Revolutions, Minutes> get() = MetricValue(Revolutions / (Minutes * Minutes), toDouble())
+val Number.s get() = MetricValue(seconds, toDouble())
+val Number.min get() = MetricValue(minutes, toDouble())
+val Number.ms get() = MetricValue(milliseconds, toDouble())
+val Number.m get() = MetricValue(meters, toDouble())
+val Number.cm get() = MetricValue(centimeters, toDouble())
+val Number.mm get() = MetricValue(millimeters, toDouble())
+val Number.deg get() = MetricValue(degrees, toDouble())
+val Number.rad get() = MetricValue(radians, toDouble())
+val Number.rev get() = MetricValue(revolutions, toDouble())
+val Number.mps: MetricValue<Velocity> get() = MetricValue(meters / seconds, toDouble())
+val Number.mmps: MetricValue<Velocity> get() = MetricValue(millimeters / seconds, toDouble())
+val Number.dps: MetricValue<AngularVelocity> get() = MetricValue(degrees / seconds, toDouble())
+val Number.rdps: MetricValue<AngularVelocity> get() = MetricValue(radians / seconds, toDouble())
+val Number.rps: MetricValue<AngularVelocity> get() = MetricValue(revolutions / seconds, toDouble())
+val Number.rpm: MetricValue<AngularVelocity> get() = MetricValue(revolutions / minutes, toDouble())
+val Number.mpss: MetricValue<Acceleration> get() = MetricValue(meters / (seconds * seconds), toDouble())
+val Number.mmpss: MetricValue<Acceleration> get() = MetricValue(millimeters / (seconds * seconds), toDouble())
+val Number.dpss: MetricValue<AngularAcceleration> get() = MetricValue(degrees / (seconds * seconds), toDouble())
+val Number.rdpss: MetricValue<AngularAcceleration> get() = MetricValue(radians / (seconds * seconds), toDouble())
+val Number.rpss: MetricValue<AngularAcceleration> get() = MetricValue(revolutions / (seconds * seconds), toDouble())
+val Number.rpmm: MetricValue<AngularAcceleration> get() = MetricValue(revolutions / (minutes * minutes), toDouble())

--- a/core/src/main/kotlin/org/sert2521/sertain/utils/Utils.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/utils/Utils.kt
@@ -4,16 +4,21 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.sert2521.sertain.coroutines.periodic
+import org.sert2521.sertain.units.Chronic
+import org.sert2521.sertain.units.MetricValue
+import org.sert2521.sertain.units.from
+import org.sert2521.sertain.units.milliseconds
+import org.sert2521.sertain.units.ms
 import kotlin.coroutines.coroutineContext
 
-suspend fun timer(period: Long = 20, delay: Long = 0, timeout: Long = 0, action: (Long) -> Unit) {
+suspend fun timer(period: MetricValue<Chronic> = 20.ms, delay: MetricValue<Chronic> = 0.ms, timeout: MetricValue<Chronic> = 0.ms, action: (Long) -> Unit) {
     val startTime = System.currentTimeMillis()
     var time: Long
-    if (timeout > 0) {
+    if (timeout.value > 0) {
         CoroutineScope(coroutineContext).launch {
             periodic(period, delay) {
                 time = System.currentTimeMillis() - startTime
-                if (time < timeout) action(time)
+                if (time < timeout.from(milliseconds)) action(time)
                 else this@launch.cancel()
             }
         }


### PR DESCRIPTION
It turns out I overestimated how useful typed units would be. This update makes it so that you cannot determine what unit a `MetricValue` is from it's type signature. This doesn't really matter though, because you can convert it to whatever unit you want. For example:
```
fun moveArm(distance: MetricValue<Linear>) {
    val d = distance.convertTo(meters).value
    // use value here
}
```
It turns out that converting a `MetricValue` to a certain unit and then getting its `value` is so common, that this update added a helper function for it. The previous function could be written as:
```
fun moveArm(distance: MetricValue<Linear>) {
    val d = distance.from(meters)
    // use value here
}
```
Note that these conversion will not be preformed if the value is already measured in the requested unit. In that case, the value will remain the same.

Another important change to note is that `periodic` and `timer` no longer accept `Long` parameters, but accept `MetricValue<Chronic>` parameters.