### PR TITLE
Control mapping

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/utils/Utils.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/utils/Utils.kt
@@ -1,33 +1,10 @@
 package org.sert2521.sertain.utils
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import org.sert2521.sertain.coroutines.periodic
-import org.sert2521.sertain.units.Chronic
-import org.sert2521.sertain.units.MetricValue
-import org.sert2521.sertain.units.from
-import org.sert2521.sertain.units.milliseconds
-import org.sert2521.sertain.units.ms
-import kotlin.coroutines.coroutineContext
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
 
-suspend fun timer(period: MetricValue<Chronic> = 20.ms, delay: MetricValue<Chronic> = 0.ms, timeout: MetricValue<Chronic> = 0.ms, action: (Long) -> Unit) {
-    val startTime = System.currentTimeMillis()
-    var time: Long
-    if (timeout.value > 0) {
-        CoroutineScope(coroutineContext).launch {
-            periodic(period, delay) {
-                time = System.currentTimeMillis() - startTime
-                if (time < timeout.from(milliseconds)) action(time)
-                else this@launch.cancel()
-            }
-        }
-    } else {
-        CoroutineScope(coroutineContext).launch {
-            periodic(period, delay) {
-                time = System.currentTimeMillis() - startTime
-                action(time)
-            }
-        }
-    }.join()
+fun <T> get(get: () -> T) = object : ReadOnlyProperty<Any?, T> {
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        return get()
+    }
 }


### PR DESCRIPTION
I thought it would be helpful to make some kind of control mapping utility. Originally it would have looked like:
```kotlin
val drive by mapping<ControlOption2, Double>(controlOption2) {
     control(ControlOption2.JOYSTICK) { joystick2.y }
     control(ControlOption2.CONTROLLER) { controller2.getY(GenericHID.Hand.kLeft) }
}
```

but as it turns out I was making it a lot more complicated. Here's what it looks like now:
```kotlin
val drive by when (controlOption2) {
    ControlOption2.JOYSTICK -> get { joystick2.y }
    ControlOption2.CONTROLLER -> get { controller2.getY(GenericHID.Hand.kLeft) }
}
```
It's just a `when` statement combined by a tiny utility function that this PR adds, `get`.