### PR TITLE
Rename event subscribers

### DIFF
--- a/core/src/main/kotlin/org/sert2521/sertain/coroutines/Observables.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/coroutines/Observables.kt
@@ -50,16 +50,16 @@ class ObservableBoolean(get: () -> Boolean) : Observable<Boolean>(get) {
 
     operator fun invoke(configure: ObservableBoolean.() -> Unit) = apply(configure)
 
+    fun CoroutineScope.onTrue(action: suspend CoroutineScope.(event: True) -> Unit) =
+            subscribe(target = this@ObservableBoolean as Observable<Boolean>, action = action)
+
+    fun CoroutineScope.onFalse(action: suspend CoroutineScope.(event: False) -> Unit) =
+            subscribe(target = this@ObservableBoolean as Observable<Boolean>, action = action)
+
     fun CoroutineScope.whenTrue(action: suspend CoroutineScope.(event: True) -> Unit) =
-            subscribe(target = this@ObservableBoolean as Observable<Boolean>, action = action)
-
-    fun CoroutineScope.whenFalse(action: suspend CoroutineScope.(event: False) -> Unit) =
-            subscribe(target = this@ObservableBoolean as Observable<Boolean>, action = action)
-
-    fun CoroutineScope.whileTrue(action: suspend CoroutineScope.(event: True) -> Unit) =
             subscribeBetween<Observable<Boolean>, True, False>(target = this@ObservableBoolean, action = action)
 
-    fun CoroutineScope.whileFalse(action: suspend CoroutineScope.(event: False) -> Unit) =
+    fun CoroutineScope.whenFalse(action: suspend CoroutineScope.(event: False) -> Unit) =
             subscribeBetween<Observable<Boolean>, False, True>(target = this@ObservableBoolean, action = action)
 }
 

--- a/core/src/main/kotlin/org/sert2521/sertain/events/RobotEventSubscribers.kt
+++ b/core/src/main/kotlin/org/sert2521/sertain/events/RobotEventSubscribers.kt
@@ -20,17 +20,17 @@ fun CoroutineScope.onAuto(action: suspend CoroutineScope.(event: Auto) -> Unit) 
 fun CoroutineScope.onTest(action: suspend CoroutineScope.(event: Test) -> Unit) =
         subscribe(action = action)
 
-fun CoroutineScope.whileDisabled(action: suspend CoroutineScope.(event: Disable) -> Unit) =
+fun CoroutineScope.whenDisabled(action: suspend CoroutineScope.(event: Disable) -> Unit) =
         subscribeBetween<Disable, Enable>(action = action)
 
-fun CoroutineScope.whileEnabled(action: suspend CoroutineScope.(event: Enable) -> Unit) =
+fun CoroutineScope.whenEnabled(action: suspend CoroutineScope.(event: Enable) -> Unit) =
         subscribeBetween<Enable, Disable>(action = action)
 
-fun CoroutineScope.whileTeleop(action: suspend CoroutineScope.(event: Teleop) -> Unit) =
+fun CoroutineScope.whenTeleop(action: suspend CoroutineScope.(event: Teleop) -> Unit) =
         subscribeBetween<Teleop, TeleopOver>(action = action)
 
-fun CoroutineScope.whileAuto(action: suspend CoroutineScope.(event: Auto) -> Unit) =
+fun CoroutineScope.whenAuto(action: suspend CoroutineScope.(event: Auto) -> Unit) =
         subscribeBetween<Auto, Disable>(action = action)
 
-fun CoroutineScope.whileTest(action: suspend CoroutineScope.(event: Test) -> Unit) =
+fun CoroutineScope.whenTest(action: suspend CoroutineScope.(event: Test) -> Unit) =
         subscribeBetween<Test, Disable>(action = action)


### PR DESCRIPTION
This just makes event subscribers a little more consistent. Now when an event subscriber launches code, the it is `onEvent`. When the code cancels on another event, it is `whenEvent`. For instance, with a button:
```kotlin
({ controller.x }).watch {
    onTrue {
        // code will run until it completes
    }
    whenTrue {
        // code will run until it completes or until value becomes `false`.
    }
} 
```